### PR TITLE
Add method joint::parentJoint() 

### DIFF
--- a/include/hpp/pinocchio/device.hh
+++ b/include/hpp/pinocchio/device.hh
@@ -161,6 +161,7 @@ namespace hpp {
       //DEPREC void registerJoint (const JointPtr_t& joint);
       /// Get vector of joints
       inline const JointVector& getJointVector () const { return jointVector_; }
+      inline JointVector& getJointVector () { return jointVector_; }
 
       /// Get the joint at configuration rank r
       JointPtr_t getJointAtConfigRank (const size_type& r) const;

--- a/include/hpp/pinocchio/joint.hh
+++ b/include/hpp/pinocchio/joint.hh
@@ -137,7 +137,7 @@ namespace hpp {
       /// \{
 
       /// Get a pointer to the parent joint (if any).
-      // DEPREC JointPtr_t parentJoint () const
+      JointPtr_t parentJoint () const;
 
       //DEPREC /// Add child joint
       //DEPREC /// \param joint child joint added to this one,
@@ -286,7 +286,7 @@ namespace hpp {
         return jointIndex;
       }
 
-      se3::JointModel& jointModel()
+      const se3::JointModel& jointModel() const
       {
         return model().joints[index()];
       }

--- a/src/joint.cc
+++ b/src/joint.cc
@@ -55,6 +55,18 @@ namespace hpp {
     se3::Data &        Joint::data()        { selfAssert(); return devicePtr->data (); }
     const se3::Data &  Joint::data()  const { selfAssert(); return devicePtr->data (); }
     
+
+    JointPtr_t Joint::parentJoint () const{
+        Index idParent = model().parents[jointIndex];
+        if(idParent == 0)
+            return JointPtr_t();
+        else{
+            Joint* jPtr = new Joint(devicePtr,idParent);
+            return JointPtr_t(jPtr);
+        }
+    }
+
+
     const std::string&  Joint::name() const 
     {
       selfAssert();


### PR DESCRIPTION
And Device return a non-const Joint vector when called from a non-const devicePtr