### PR TITLE
Allow to attach a robot at a specified frame.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,7 @@ SEARCH_FOR_BOOST()
 
 # Search for dependecies.
 ADD_REQUIRED_DEPENDENCY("hpp-util >= 3.2")
-ADD_REQUIRED_DEPENDENCY("pinocchio >= 2.0")
+ADD_REQUIRED_DEPENDENCY("pinocchio >= 2.1.2")
 ADD_REQUIRED_DEPENDENCY("eigen3 >= 3.2.92")
 
 ADD_OPTIONAL_DEPENDENCY("romeo_description >= 0.2")

--- a/include/hpp/pinocchio/device-data.hh
+++ b/include/hpp/pinocchio/device-data.hh
@@ -32,7 +32,7 @@ namespace hpp {
       JACOBIAN       = 0x2,
       VELOCITY       = 0x4,
       ACCELERATION   = 0x8,
-      COM            = 0x16,
+      COM            = 0xf,
       COMPUTE_ALL    = 0Xffff
     };
 

--- a/include/hpp/pinocchio/frame.hh
+++ b/include/hpp/pinocchio/frame.hh
@@ -36,7 +36,7 @@ namespace hpp {
       /// Constructor
       /// \param device pointer on the device the frame is belonging to.
       /// \param indexInFrameList index of the frame, i.e. frame = device.model.frames[index]
-      Frame (DevicePtr_t device, FrameIndex indexInFrameList );
+      Frame (DeviceWkPtr_t device, FrameIndex indexInFrameList );
 
       ~Frame() {}
       /// \}
@@ -55,11 +55,16 @@ namespace hpp {
       /// Frame transformation
       Transform3f currentTransformation () const;
 
+      /// Frame transformation
+      Transform3f currentTransformation (const DeviceData& data) const;
+
       /// Get const reference to Jacobian
       ///
       /// The jacobian (6d) is expressed in the local frame.
       /// the linear part corresponds to the velocity of the center of the frame.
-      JointJacobian_t jacobian () const;
+      JointJacobian_t jacobian () const { return jacobian (data()); }
+
+      JointJacobian_t jacobian (const DeviceData& data) const;
 
       ///\}
       // -----------------------------------------------------------------------
@@ -99,9 +104,9 @@ namespace hpp {
       // -----------------------------------------------------------------------
 
       /// Access robot owning the object
-      DeviceConstPtr_t robot () const { selfAssert();  return devicePtr_;}
+      DeviceConstPtr_t robot () const { selfAssert();  return devicePtr_.lock();}
       /// Access robot owning the object
-      DevicePtr_t robot () { selfAssert(); return devicePtr_;}
+      DevicePtr_t robot () { selfAssert(); return devicePtr_.lock();}
 
       /// Display frame
       virtual std::ostream& display (std::ostream& os) const;
@@ -119,7 +124,7 @@ namespace hpp {
       /// \}
 
     private:
-      DevicePtr_t devicePtr_;
+      DeviceWkPtr_t devicePtr_;
       FrameIndex frameIndex_;
       std::vector<FrameIndex> children_;
 
@@ -129,8 +134,7 @@ namespace hpp {
       void setChildList();
       Model&        model() ;
       const Model&  model() const ;
-      Data &        data()  ;
-      const Data &  data()  const ;
+      DeviceData& data() const;
 
       /// Assert that the members of the struct are valid (no null pointer, etc).
       void selfAssert() const;

--- a/include/hpp/pinocchio/urdf/util.hh
+++ b/include/hpp/pinocchio/urdf/util.hh
@@ -35,7 +35,7 @@ namespace hpp
       ///
       /// \param robot Empty robot created before calling the function.
       ///        Users can pass an instance of a class deriving from Device.
-      /// \param baseJoint joint to which the joint tree is added.
+      /// \param baseFrame frame to which the joint tree is added.
       /// \param prefix string to insert before all names
       ///               (joint, link, body names)
       /// \param rootJointType type of root joint among "anchor", "freeflyer",
@@ -51,7 +51,7 @@ namespace hpp
       /// \li
       /// package://${package}/srdf/${modelName}${srdfSuffix}.srdf
       void loadRobotModel (const DevicePtr_t& robot,
-                           const JointIndex&  baseJoint,
+                           const FrameIndex&  baseFrame,
 			   const std::string& prefix,
 			   const std::string& rootJointType,
 			   const std::string& package,
@@ -74,7 +74,7 @@ namespace hpp
       ///
       /// \param robot Empty robot created before calling the function.
       ///        Users can pass an instance of a class deriving from Device.
-      /// \param baseJoint joint to which the joint tree is added.
+      /// \param baseFrame frame to which the joint tree is added.
       /// \param prefix string to insert before all names
       ///               (joint, link, body names)
       /// \param rootJointType type of root joint among "anchor", "freeflyer",
@@ -86,7 +86,7 @@ namespace hpp
       /// \li
       /// package://${package}/urdf/${filename}.urdf
       void loadUrdfModel (const DevicePtr_t& robot,
-                          const JointIndex&  baseJoint,
+                          const FrameIndex&  baseFrame,
                           const std::string& prefix,
 			  const std::string& rootJointType,
 			  const std::string& package,
@@ -101,7 +101,7 @@ namespace hpp
       /// robot.
       /// \param srdfPath if empty, do not try to parse SRDF.
       void loadModel (const DevicePtr_t& robot,
-                      const JointIndex&  baseJoint,
+                      const FrameIndex&  baseFrame,
                       const std::string& prefix,
                       const std::string& rootType,
                       const std::string& urdfPath,
@@ -110,7 +110,7 @@ namespace hpp
       /// Read URDF and, optionnally SRDF, as XML string.
       /// \param srdfString if empty, do not try to parse SRDF.
       void loadModelFromString (const DevicePtr_t& robot,
-                                const JointIndex&  baseJoint,
+                                const FrameIndex&  baseFrame,
                                 const std::string& prefix,
                                 const std::string& rootType,
                                 const std::string& urdfString,

--- a/src/urdf/util.cc
+++ b/src/urdf/util.cc
@@ -251,6 +251,8 @@ namespace hpp {
                 robot->geomModel(), geomModel,
                 baseFrame, Transform3f::Identity(),
                 *m, *gm);
+            robot->setModel (m);
+            robot->setGeomModel (gm);
           }
 
           robot->createData();

--- a/src/urdf/util.cc
+++ b/src/urdf/util.cc
@@ -216,7 +216,7 @@ namespace hpp {
           GeomModel geomModel;
 
           std::vector<std::string> baseDirs = ::pinocchio::rosPaths();
-          fcl::MeshLoaderPtr loader (new fcl::CachedMeshLoader (fcl::BV_OBBRSS));
+          fcl::MeshLoaderPtr loader (new fcl::CachedMeshLoader (fcl::BV_OBB));
           ::pinocchio::urdf::buildGeom(*model, urdfStream, ::pinocchio::COLLISION, geomModel, baseDirs, loader);
           geomModel.addAllCollisionPairs();
 

--- a/src/urdf/util.cc
+++ b/src/urdf/util.cc
@@ -216,7 +216,7 @@ namespace hpp {
           GeomModel geomModel;
 
           std::vector<std::string> baseDirs = ::pinocchio::rosPaths();
-          fcl::MeshLoaderPtr loader (new fcl::CachedMeshLoader (fcl::BV_OBB));
+          static fcl::MeshLoaderPtr loader (new fcl::CachedMeshLoader (fcl::BV_OBB));
           ::pinocchio::urdf::buildGeom(*model, urdfStream, ::pinocchio::COLLISION, geomModel, baseDirs, loader);
           geomModel.addAllCollisionPairs();
 


### PR DESCRIPTION
58118f0 makes the MeshLoader static. This is questionable since the FCL objects will not be released even after destroying a problem. When relaunching the same script however, it speeds up creating the robot, since the mesh files are already parsed and stored into memory.