### PR TITLE
Device::getFrameByName returns all type of frames

### DIFF
--- a/include/hpp/pinocchio/joint-collection.hh
+++ b/include/hpp/pinocchio/joint-collection.hh
@@ -28,6 +28,7 @@
 #include "pinocchio/multibody/joint/joint-planar.hpp"
 #include "pinocchio/multibody/joint/joint-prismatic.hpp"
 #include "pinocchio/multibody/joint/joint-revolute-unaligned.hpp"
+#include "pinocchio/multibody/joint/joint-revolute-unbounded-unaligned.hpp"
 #include "pinocchio/multibody/joint/joint-prismatic-unaligned.hpp"
 #include "pinocchio/multibody/joint/joint-revolute.hpp"
 #include "pinocchio/multibody/joint/joint-revolute-unbounded.hpp"
@@ -56,7 +57,10 @@ namespace hpp {
       typedef ::pinocchio::JointModelRevoluteUnboundedTpl<Scalar,Options,0> JointModelRUBX;
       typedef ::pinocchio::JointModelRevoluteUnboundedTpl<Scalar,Options,1> JointModelRUBY;
       typedef ::pinocchio::JointModelRevoluteUnboundedTpl<Scalar,Options,2> JointModelRUBZ;
-      
+
+      // Joint Revolute Unbounded Unaligned
+      typedef ::pinocchio::JointModelRevoluteUnboundedUnalignedTpl<Scalar,Options> JointModelRevoluteUnboundedUnaligned;
+
       // Joint Prismatic
       typedef ::pinocchio::JointModelPrismaticTpl<Scalar,Options,0> JointModelPX;
       typedef ::pinocchio::JointModelPrismaticTpl<Scalar,Options,1> JointModelPY;
@@ -88,6 +92,7 @@ namespace hpp {
       JointModelRX, JointModelRY, JointModelRZ
       , JointModelFreeFlyer, JointModelPlanar
       , JointModelRevoluteUnaligned
+      , JointModelRevoluteUnboundedUnaligned
       , JointModelPX, JointModelPY, JointModelPZ
       , JointModelPrismaticUnaligned
       , JointModelTranslation
@@ -107,6 +112,9 @@ namespace hpp {
       typedef ::pinocchio::JointDataRevoluteUnboundedTpl<Scalar,Options,0> JointDataRUBX;
       typedef ::pinocchio::JointDataRevoluteUnboundedTpl<Scalar,Options,1> JointDataRUBY;
       typedef ::pinocchio::JointDataRevoluteUnboundedTpl<Scalar,Options,2> JointDataRUBZ;
+    
+      // Joint Revolute Unbounded Unaligned
+      typedef ::pinocchio::JointDataRevoluteUnboundedUnalignedTpl<Scalar,Options> JointDataRevoluteUnboundedUnaligned;
       
       // Joint Prismatic
       typedef ::pinocchio::JointDataPrismaticTpl<Scalar,Options,0> JointDataPX;
@@ -139,6 +147,7 @@ namespace hpp {
       JointDataRX, JointDataRY, JointDataRZ
       , JointDataFreeFlyer, JointDataPlanar
       , JointDataRevoluteUnaligned
+      , JointDataRevoluteUnboundedUnaligned
       , JointDataPX, JointDataPY, JointDataPZ
       , JointDataPrismaticUnaligned
       , JointDataTranslation

--- a/include/hpp/pinocchio/liegroup.hh
+++ b/include/hpp/pinocchio/liegroup.hh
@@ -29,6 +29,8 @@
 
 namespace hpp {
   namespace pinocchio {
+    typedef ::pinocchio::JointModelCompositeTpl<value_type, 0, JointCollectionTpl> JointModelComposite;
+
     /// This class maps at compile time a joint type to a lie group type.
     ///
     /// JointModelPlanar (JointModelFreeFlyer resp.) maps to
@@ -53,7 +55,7 @@ namespace hpp {
 
     /// \cond
     //---------------- RnxSOnLieGroupMap -------------------------------//
-    // JointModelRevolute, JointModelRevoluteUnbounded, JointModelRevoluteUnaligned
+    // JointModelRevolute, JointModelRevoluteUnbounded, JointModelRevoluteUnaligned, JointModelRevoluteUnboundedUnaligned
     template<typename Scalar, int Options, int Axis>
     struct RnxSOnLieGroupMap::operation < ::pinocchio::JointModelRevoluteTpl<Scalar, Options, Axis> > {
       typedef liegroup::VectorSpaceOperation<1, true> type;
@@ -65,6 +67,10 @@ namespace hpp {
     template<typename Scalar, int Options>
     struct RnxSOnLieGroupMap::operation < ::pinocchio::JointModelRevoluteUnalignedTpl<Scalar, Options> > {
       typedef liegroup::VectorSpaceOperation<1, true> type;
+    };
+    template<typename Scalar, int Options>
+    struct RnxSOnLieGroupMap::operation < ::pinocchio::JointModelRevoluteUnboundedUnalignedTpl<Scalar, Options> > {
+      typedef liegroup::SpecialOrthogonalOperation<2> type;
     };
 
     // JointModelPrismaticTpl, JointModelPrismaticUnaligned, JointModelTranslation
@@ -109,7 +115,7 @@ namespace hpp {
 
     //---------------- DefaultLieGroupMap ------------------------------------//
 
-    // JointModelRevolute, JointModelRevoluteUnbounded, JointModelRevoluteUnaligned
+    // JointModelRevolute, JointModelRevoluteUnbounded, JointModelRevoluteUnaligned, JointModelRevoluteUnboundedUnaligned
     template<typename Scalar, int Options, int Axis>
     struct DefaultLieGroupMap::operation < ::pinocchio::JointModelRevoluteTpl<Scalar, Options, Axis> > {
       typedef liegroup::VectorSpaceOperation<1, true> type;
@@ -122,6 +128,11 @@ namespace hpp {
     struct DefaultLieGroupMap::operation < ::pinocchio::JointModelRevoluteUnalignedTpl<Scalar, Options> > {
       typedef liegroup::VectorSpaceOperation<1, true> type;
     };
+    template<typename Scalar, int Options>
+    struct DefaultLieGroupMap::operation < ::pinocchio::JointModelRevoluteUnboundedUnalignedTpl<Scalar, Options> > {
+      typedef liegroup::SpecialOrthogonalOperation<2> type;
+    };
+
 
     // JointModelPrismaticTpl, JointModelPrismaticUnaligned, JointModelTranslation
     template<typename Scalar, int Options, int Axis>

--- a/include/hpp/pinocchio/urdf/util.hh
+++ b/include/hpp/pinocchio/urdf/util.hh
@@ -46,10 +46,8 @@ namespace hpp
       /// \param srdfSuffix suffix for srdf file
 
       /// \note This function reads the following files:
-      /// \li
-      /// package://${package}/urdf/${modelName}${urdfSuffix}.urdf
-      /// \li
-      /// package://${package}/srdf/${modelName}${srdfSuffix}.srdf
+      /// \li \c package://${package}/urdf/${modelName}${urdfSuffix}.urdf
+      /// \li \c package://${package}/srdf/${modelName}${srdfSuffix}.srdf
       void loadRobotModel (const DevicePtr_t& robot,
                            const FrameIndex&  baseFrame,
 			   const std::string& prefix,

--- a/src/configuration.cc
+++ b/src/configuration.cc
@@ -224,7 +224,7 @@ namespace hpp {
     };
 
     template<>
-    void IsNormalizedStep::algo< ::pinocchio::JointModelComposite>(const ::pinocchio::JointModelBase< ::pinocchio::JointModelComposite> & jmodel,
+    void IsNormalizedStep::algo< JointModelComposite>(const ::pinocchio::JointModelBase< JointModelComposite> & jmodel,
                      ConfigurationIn_t q,
                      const value_type & eps,
                      bool & ret)

--- a/src/device.cc
+++ b/src/device.cc
@@ -245,11 +245,11 @@ namespace hpp {
     Frame Device::
     getFrameByName (const std::string& name) const
     {
-      if(! model().existFrame(name, all_joint_type))
+      if(! model().existFrame(name))
 	throw std::logic_error ("Device " + name_ +
 				" does not have any frame named "
 				+ name);
-      FrameIndex id = model().getFrameId(name, all_joint_type);
+      FrameIndex id = model().getFrameId(name);
       return Frame(weakPtr_.lock(), id);
     }
 

--- a/src/device.cc
+++ b/src/device.cc
@@ -411,8 +411,8 @@ namespace hpp {
     };
 
     template <>
-    void AABBStep::algo< ::pinocchio::JointModelComposite >(
-        const ::pinocchio::JointModelBase< ::pinocchio::JointModelComposite > & jmodel,
+    void AABBStep::algo< JointModelComposite >(
+        const ::pinocchio::JointModelBase< JointModelComposite > & jmodel,
         const Model& model,
         Configuration_t q,
         bool initializeAABB,
@@ -421,7 +421,7 @@ namespace hpp {
       // TODO this should for but I did not test it.
       hppDout(warning, "Computing AABB of JointModelComposite should work but has never been tested");
       if (initializeAABB)  {
-        ::pinocchio::JointModelComposite::JointDataDerived data = jmodel.createData();
+        JointModelComposite::JointDataDerived data = jmodel.createData();
         jmodel.calc(data, q);
         aabb = fcl::AABB(data.M.translation());
       }

--- a/src/joint.cc
+++ b/src/joint.cc
@@ -530,7 +530,7 @@ namespace hpp {
         space *= LiegroupSpace::create (LG_t());
       }
 
-      static void _algo (const ::pinocchio::JointModelComposite& jmodel,
+      static void _algo (const JointModelComposite& jmodel,
                        LiegroupSpace& space)
       {
         ::pinocchio::details::Dispatch<ConfigSpaceVisitor>::run(jmodel,

--- a/src/joint/bound.hh
+++ b/src/joint/bound.hh
@@ -40,8 +40,8 @@ namespace hpp {
       };
 
       template <>
-      void SetBoundStep::algo< ::pinocchio::JointModelComposite>(
-          const ::pinocchio::JointModelBase< ::pinocchio::JointModelComposite> & jmodel,
+      void SetBoundStep::algo<JointModelComposite>(
+          const ::pinocchio::JointModelBase<JointModelComposite> & jmodel,
           ConfigurationIn_t bounds,
           Configuration_t & out)
       {


### PR DESCRIPTION
* before it was only JOINT and fIXED_JOINT.