### PR TITLE
Device::getFrameByName returns all type of frames

### DIFF
--- a/include/hpp/pinocchio/urdf/util.hh
+++ b/include/hpp/pinocchio/urdf/util.hh
@@ -46,10 +46,8 @@ namespace hpp
       /// \param srdfSuffix suffix for srdf file
 
       /// \note This function reads the following files:
-      /// \li
-      /// package://${package}/urdf/${modelName}${urdfSuffix}.urdf
-      /// \li
-      /// package://${package}/srdf/${modelName}${srdfSuffix}.srdf
+      /// \li \c package://${package}/urdf/${modelName}${urdfSuffix}.urdf
+      /// \li \c package://${package}/srdf/${modelName}${srdfSuffix}.srdf
       void loadRobotModel (const DevicePtr_t& robot,
                            const FrameIndex&  baseFrame,
 			   const std::string& prefix,

--- a/src/device.cc
+++ b/src/device.cc
@@ -245,11 +245,11 @@ namespace hpp {
     Frame Device::
     getFrameByName (const std::string& name) const
     {
-      if(! model().existFrame(name, all_joint_type))
+      if(! model().existFrame(name))
 	throw std::logic_error ("Device " + name_ +
 				" does not have any frame named "
 				+ name);
-      FrameIndex id = model().getFrameId(name, all_joint_type);
+      FrameIndex id = model().getFrameId(name);
       return Frame(weakPtr_.lock(), id);
     }
 


### PR DESCRIPTION
Because I don't see any reason not to do so.