### PR TITLE
[LiegroupSpace] Enable users to create R1 with rotation template

### DIFF
--- a/include/hpp/pinocchio/liegroup-space.hh
+++ b/include/hpp/pinocchio/liegroup-space.hh
@@ -100,7 +100,9 @@ namespace hpp {
       /// \param n dimension of vector space
       static LiegroupSpacePtr_t Rn (const size_type& n);
       /// Return \f$\mathbf{R}\f$ as a Lie group
-      static LiegroupSpacePtr_t R1 ();
+      /// \param rotation whether values of this space represent angles or
+      ///        lengths.
+      static LiegroupSpacePtr_t R1 (bool rotation=false);
       /// Return \f$\mathbf{R}^2\f$ as a Lie group
       static LiegroupSpacePtr_t R2 ();
       /// Return \f$\mathbf{R}^3\f$ as a Lie group

--- a/src/liegroup-space.cc
+++ b/src/liegroup-space.cc
@@ -34,10 +34,17 @@ namespace hpp {
     }
 
     /// Return \f$\mathbf{R}\f$ as a Lie group
-    LiegroupSpacePtr_t LiegroupSpace::R1 ()
+    LiegroupSpacePtr_t LiegroupSpace::R1 (bool rotation)
     {
-      LiegroupSpace* ptr (new LiegroupSpace
-                          (liegroup::VectorSpaceOperation <1, false> ()));
+      LiegroupSpace* ptr;
+      if (rotation)
+      {
+        ptr = new LiegroupSpace(liegroup::VectorSpaceOperation <1, true> ());
+      }
+      else
+      {
+        ptr = new LiegroupSpace(liegroup::VectorSpaceOperation <1, false> ());
+      }
       LiegroupSpacePtr_t  shPtr (ptr);
       ptr->init (shPtr);
       return shPtr;


### PR DESCRIPTION
argument

  - formerly, template argument rotation was set to false.
    This is particularly useful to compare rotation joint configuration spaces
    with R1.