### PR TITLE
add required consts for C++17

### DIFF
--- a/include/hpp/pinocchio/serialization.hh
+++ b/include/hpp/pinocchio/serialization.hh
@@ -94,13 +94,13 @@ namespace serialization {
 namespace remove_duplicate {
 template<typename Key, typename Compare = std::less<Key> >
 struct ptr_less : Compare {
-  inline bool operator() (Key const* t1, Key const* t2) { return Compare::operator() (*t1, *t2); }
+  inline bool operator() (Key const* t1, Key const* t2) const { return Compare::operator() (*t1, *t2); }
 };
 
 template<typename Derived>
 struct eigen_compare {
   bool operator() (const Eigen::PlainObjectBase<Derived>& a,
-                   const Eigen::PlainObjectBase<Derived>& b)
+                   const Eigen::PlainObjectBase<Derived>& b) const
   {
     if (a.size() < b.size()) return true;
     if (a.size() > b.size()) return false;


### PR DESCRIPTION
Hi,

I don't know when this appeared, but with GCC 11.1.0, Boost 1.75.0 & eigen 3.3.9, and without this:

```
[11/35] Building CXX object CMakeFiles/hpp-pinocchio.dir/src/liegroup-element.cc.o
FAILED: CMakeFiles/hpp-pinocchio.dir/src/liegroup-element.cc.o
/usr/lib/ccache/bin/g++ -DBOOST_ALL_NO_LIB -DBOOST_FILESYSTEM_DYN_LINK -DBOOST_MPL_LIMIT_LIST_SIZE=30 -DBOOST_MPL_LIMIT_VECTOR_SIZE=30 -DBOOST_SERIALIZATION_DYN_LINK -DBOOST_THREAD_DYN_LINK -DHPP_FCL_HAS_OCTOMAP -DHPP_FCL_HAVE_OCTOMAP -DOCTOMAP_MAJOR_VERSION=1 -DOCTOMAP_MINOR_VERSION=9 -DOCTOMAP_PATCH_VERSION=6 -DPINOCCHIO_WITH_HPP_FCL -DPINOCCHIO_WITH_URDFDOM -Dhpp_pinocchio_EXPORTS -I. -Iinclude -I../include -isystem $ROBOTPKG/include -isystem /usr/include/eigen3 -pedantic -Wno-long-long -Wall -Wextra -Wcast-align -Wcast-qual -Wformat -Wwrite-strings -Wconversion -fdiagnostics-color=always -fPIC -MD -MT CMakeFiles/hpp-pinocchio.dir/src/liegroup-element.cc.o -MF CMakeFiles/hpp-pinocchio.dir/src/liegroup-element.cc.o.d -o CMakeFiles/hpp-pinocchio.dir/src/liegroup-element.cc.o -c ../src/liegroup-element.cc
Dans le fichier inclus depuis /usr/include/c++/11.1.0/set:60,
                 depuis /usr/include/hpp/fcl/collision_data.h:43,
                 depuis ../include/hpp/pinocchio/fwd.hh:32,
                 depuis ../include/hpp/pinocchio/liegroup/vector-space.hh:24,
                 depuis ../include/hpp/pinocchio/liegroup.hh:25,
                 depuis ../include/hpp/pinocchio/liegroup-space.hh:28,
                 depuis ../include/hpp/pinocchio/liegroup-element.hh:20,
                 depuis ../src/liegroup-element.cc:17:
/usr/include/c++/11.1.0/bits/stl_tree.h: Dans l'instanciation de « static const _Key& std::_Rb_tree<_Key, _Val, _KeyOfValue, _Compare, _Alloc>::_S_key(std::_Rb_tree<_Key, _Val, _KeyOfValue, _Compare, _Alloc>::_Const_Link_type) [with _Key = const Eigen::Matrix<double, -1, 1>*; _Val = const Eigen::Matrix<double, -1, 1>*; _KeyOfValue = std::_Identity<const Eigen::Matrix<double, -1, 1>*>; _Compare = hpp::serialization::remove_duplicate::ptr_less<Eigen::Matrix<double, -1, 1>, hpp::serialization::remove_duplicate::eigen_compare<Eigen::Matrix<double, -1, 1> > >; _Alloc = std::allocator<const Eigen::Matrix<double, -1, 1>*>; std::_Rb_tree<_Key, _Val, _KeyOfValue, _Compare, _Alloc>::_Const_Link_type = const std::_Rb_tree_node<const Eigen::Matrix<double, -1, 1>*>*] » :
/usr/include/c++/11.1.0/bits/stl_tree.h:2069:47:   requis par « std::pair<std::_Rb_tree_node_base*, std::_Rb_tree_node_base*> std::_Rb_tree<_Key, _Val, _KeyOfValue, _Compare, _Alloc>::_M_get_insert_unique_pos(const key_type&) [with _Key = const Eigen::Matrix<double, -1, 1>*; _Val = const Eigen::Matrix<double, -1, 1>*; _KeyOfValue = std::_Identity<const Eigen
::Matrix<double, -1, 1>*>; _Compare = hpp::serialization::remove_duplicate::ptr_less<Eigen::Matrix<double, -1, 1>, hpp::serialization::remove_duplicate::eigen_compare<Eigen::Matrix<double, -1, 1> > >; _Alloc = std::allocator<const Eigen::Matrix<double, -1, 1>*>; std::_Rb_tree<_Key, _Val, _KeyOfValue, _Compare, _Alloc>::key_type = const Eigen::Matrix<double, -1, 1>*] »
/usr/include/c++/11.1.0/bits/stl_tree.h:2122:4:   requis par « std::pair<std::_Rb_tree_iterator<_Val>, bool> std::_Rb_tree<_Key, _Val, _KeyOfValue, _Compare, _Alloc>::_M_insert_unique(_Arg&&) [with _Arg = const Eigen::Matrix<double, -1, 1>*; _Key = const Eigen::Matrix<double, -1, 1>*; _Val = const Eigen::Matrix<double, -1, 1>*; _KeyOfValue = std::_Identity<const Eigen::Matrix<double, -1, 1>*>; _Compare = hpp::serialization::remove_duplicate::ptr_less<Eigen::Matrix<double, -1, 1>, hpp::serialization::remove_duplicate::eigen_compare<Eigen::Matrix<double, -1, 1> > >; _Alloc = std::allocator<const Eigen::Matrix<double, -1, 1>*>] »
/usr/include/c++/11.1.0/bits/stl_set.h:521:25:   requis par « std::pair<typename std::_Rb_tree<_Key, _Key, std::_Identity<_Tp>, _Compare, typename __gnu_cxx::__alloc_traits<_Allocator>::rebind<_Key>::other>::const_iterator, bool> std::set<_Key, _Compare, _Alloc>::insert(std::set<_Key, _Compare, _Alloc>::value_type&&) [with _Key = const Eigen::Matrix<double, -1, 1>*; _Compare = hpp::serialization::remove_duplicate::ptr_less<Eigen::Matrix<double, -1, 1>, hpp::serialization::remove_duplicate::eigen_compare<Eigen::Matrix<double, -1, 1> > >; _Alloc = std::allocator<const Eigen::Matrix<double, -1, 1>*>; typename std::_Rb_tree<_Key, _Key, std::_Identity<_Tp>, _Compare, typename __gnu_cxx::__alloc_traits<_Allocator>::rebind<_Key>::other>::const_iterator = std::_Rb_tree<const Eigen::Matrix<double, -1, 1>*, const Eigen::Matrix<double, -1, 1>*, std::_Identity<const Eigen::Matrix<double, -1, 1>*>, hpp::serialization::remove_duplicate::ptr_less<Eigen::Matrix<double, -1, 1>, hpp::serialization::remove_duplicate::eigen_compare<Eigen::Matrix<double, -1, 1> > >, std::allocator<const Eigen::Matrix<double, -1, 1>*> >::const_iterator; typename __gnu_cxx::__alloc_traits<_Allocator>::rebind<_Key>::other = std::allocator<const Eigen::Matrix<double, -1, 1>*>; typename __gnu_cxx::__alloc_traits<_Allocator>::rebind<_Key> = __gnu_cxx::__alloc_traits<std::allocator<const Eigen::Matrix<double, -1, 1>*>, const Eigen::Matrix<double, -1, 1>*>::rebind<const Eigen::Matrix<double, -1, 1>*>; typename _Allocator::value_type = const Eigen::Matrix<double, -1, 1>*; std::set<_Key, _Compare, _Alloc>::value_type = const Eigen::Matrix<double, -1, 1>*] »
../include/hpp/pinocchio/serialization.hh:161:27:   requis par « void hpp::serialization::remove_duplicate::save_impl(Archive&, std::set<const Key*, hpp::serialization::remove_duplicate::ptr_less<Key, Compare> >&, int&, const char*, const Key&, unsigned int) [with Archive = boost::archive::xml_oarchive; Key = Eigen::Matrix<double, -1, 1>; Compare = hpp::serialization::remove_duplicate::eigen_compare<Eigen::Matrix<double, -1, 1> >] »
../include/hpp/pinocchio/serialization.hh:201:12:   requis par « static void hpp::serialization::remove_duplicate::serialiaze_impl<is_base>::save(Archive&, const char*, const Key&, unsigned int) [with Archive = boost::archive::xml_oarchive; Key = Eigen::Matrix<double, -1, 1>; Compare = hpp::serialization::remove_duplicate::eigen_compare<Eigen::Matrix<double, -1, 1> >; bool is_base = true] »
../include/hpp/pinocchio/serialization.hh:225:55:   [ passe outre 2 contextes d'instanciation, utilisez -ftemplate-backtrace-limit=0 pour désactiver ]
../include/hpp/pinocchio/serialization.hh:268:5:   requis par « void hpp::serialization::remove_duplicate::save_vector(Archive&, const char*, const vector_t&, unsigned int) [with Archive = boost::archive::xml_oarchive; hpp::pinocchio::vector_t = Eigen::Matrix<double, -1, 1>] »
../src/liegroup-element.cc:134:52:   requis par « void boost::serialization::save(Archive&, const LiegroupElement&, unsigned int) [with Archive = boost::archive::xml_oarchive; hpp::pinocchio::LiegroupElement = hpp::pinocchio::LiegroupElementBase<Eigen::Matrix<double, -1, 1> >] »
/usr/include/boost/serialization/split_free.hpp:45:13:   requis par « static void boost::serialization::free_saver<Archive, T>::invoke(Archive&, const T&, unsigned int) [with Archive = boost::archive::xml_oarchive; T = hpp::pinocchio::LiegroupElementBase<Eigen::Matrix<double, -1, 1> >] »
/usr/include/boost/serialization/split_free.hpp:74:18:   requis par « void boost::serialization::split_free(Archive&, T&, unsigned int) [with Archive = boost::archive::xml_oarchive; T = hpp::pinocchio::LiegroupElementBase<Eigen::Matrix<double, -1, 1> >] »
../src/liegroup-element.cc:139:1:   requis par « void boost::serialization::serialize(Archive&, hpp::pinocchio::LiegroupElement&, unsigned int) [with Archive = boost::archive::xml_oarchive; hpp::pinocchio::LiegroupElement = hpp::pinocchio::LiegroupElementBase<Eigen::Matrix<double, -1, 1> >] »
../src/liegroup-element.cc:139:1:   requis depuis ici
/usr/include/c++/11.1.0/bits/stl_tree.h:770:15: erreur: l'assertion statique a échoué: comparison object must be invocable as const
  770 |               is_invocable_v<const _Compare&, const _Key&, const _Key&>,
      |               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/11.1.0/bits/stl_tree.h:770:15: note: « std::is_invocable_v<const hpp::serialization::remove_duplicate::ptr_less<Eigen::Matrix<double, -1, 1>, hpp::serialization::remove_duplicate::eigen_compare<Eigen::Matrix<double, -1, 1> > >&, const Eigen::Matrix<double, -1, 1, 0, -1, 1>* const&, const Eigen::Matrix<double, -1, 1, 0, -1, 1>* const&> » est évalué à « faux »
```