### PR TITLE
Add clearer docs for methods about joint index

### DIFF
--- a/include/hpp/pinocchio/device.hh
+++ b/include/hpp/pinocchio/device.hh
@@ -157,9 +157,13 @@ class HPP_PINOCCHIO_DLLAPI Device : public AbstractDevice {
   Frame rootFrame() const;
 
   /// Get number of joints
+  /// \note "universe" is not included in the count
   size_type nbJoints() const;
 
   /// Access i-th joint
+  /// \param i index of joint in device. This is 1 less than index of joint
+  ///        in pinocchio vector of joints (pinocchio::ModelTpl::joints)
+  ///        since "universe" is not included as index 0
   JointPtr_t jointAt(const size_type& i) const;
 
   /// Get the joint at configuration rank r


### PR DESCRIPTION
pinocchio considers "universe" as joint index 0. However, for
hpp-pinocchio, some methods consider "universe" while others do not.
This should be documented clearly in the header to prevent
misunderstanding.

I found it extremely easy to fall into the trap of thinking, for the below code,
```cpp
DevicePtr_t robot = ...;
JointPtr_t j1 = ...;
robot.jointAt(j1.index());
```
that the third line would return the same joint as `j1` when indeed it does not.