### PR TITLE
Add method to get joint index including universe

### DIFF
--- a/include/hpp/pinocchio/fwd.hh
+++ b/include/hpp/pinocchio/fwd.hh
@@ -122,6 +122,7 @@ typedef shared_ptr<HumanoidRobot> HumanoidRobotPtr_t;
 typedef shared_ptr<CenterOfMassComputation> CenterOfMassComputationPtr_t;
 typedef shared_ptr<Joint> JointPtr_t;
 typedef shared_ptr<const Joint> JointConstPtr_t;
+typedef Joint Joint;
 typedef shared_ptr<Gripper> GripperPtr_t;
 typedef std::vector<GripperPtr_t> Grippers_t;
 

--- a/include/hpp/pinocchio/joint.hh
+++ b/include/hpp/pinocchio/joint.hh
@@ -244,8 +244,7 @@ class HPP_PINOCCHIO_DLLAPI Joint {
   /// Get the index for a given joint
   ///
   /// \return 0 if joint is NULL ("universe"), joint->index() otherwise.
-  static inline size_type index(const JointConstPtr_t& joint)
-  {
+  static inline size_type index(const JointConstPtr_t& joint) {
     return (joint ? joint->index() : 0);
   }
 

--- a/include/hpp/pinocchio/joint.hh
+++ b/include/hpp/pinocchio/joint.hh
@@ -241,6 +241,14 @@ class HPP_PINOCCHIO_DLLAPI Joint {
 
   const JointIndex& index() const { return jointIndex; }
 
+  /// Get the index for a given joint
+  ///
+  /// \return 0 if joint is NULL ("universe"), joint->index() otherwise.
+  static inline size_type index(const JointConstPtr_t& joint)
+  {
+    return (joint ? joint->index() : 0);
+  }
+
   const JointModel& jointModel() const;
 
   /// \}


### PR DESCRIPTION
The member index() method is only usable if the joint is not NULL.
We could not get index from an empty pointer that supposedly represents
the "universe" joint. Having a static method that deals with this will
help to streamline a lot of codes requiring joint index. Previously
this method is only available in hpp-core::RelativeMotion which is not
obvious at all.