### PR TITLE
convert boost/std CollisionGeometryPtr

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,7 @@ ENDIF(CMAKE_BUILD_TYPE MATCHES "DEBUG")
 ADD_PROJECT_DEPENDENCY(Boost REQUIRED COMPONENTS thread)
 
 # Search for dependecies.
+ADD_PROJECT_DEPENDENCY(hpp-fcl 2.0.1 REQUIRED)
 ADD_PROJECT_DEPENDENCY(hpp-util 4.10.0 REQUIRED)
 ADD_PROJECT_DEPENDENCY(pinocchio REQUIRED)
 ADD_PROJECT_DEPENDENCY(Eigen3 REQUIRED)
@@ -98,6 +99,7 @@ SET(${PROJECT_NAME}_HEADERS
   include/hpp/pinocchio/util.hh
   include/hpp/pinocchio/pool.hh
   include/hpp/pinocchio/serialization.hh
+  include/hpp/pinocchio/shared-ptr.hh
 
   include/hpp/pinocchio/liegroup.hh
   include/hpp/pinocchio/liegroup-element.hh
@@ -134,6 +136,7 @@ SET(${PROJECT_NAME}_SOURCES
   src/substraction-visitor.hh
   src/urdf/util.cc
   src/util.cc
+  src/shared-ptr.cc
   )
 
 ADD_LIBRARY(${PROJECT_NAME} SHARED ${${PROJECT_NAME}_SOURCES} ${${PROJECT_NAME}_HEADERS})

--- a/include/hpp/pinocchio/shared-ptr.hh
+++ b/include/hpp/pinocchio/shared-ptr.hh
@@ -1,10 +1,12 @@
 #ifndef HPP_PINOCCHIO_SHARED_PTR_HH
 #define HPP_PINOCCHIO_SHARED_PTR_HH
 
-#include <boost/make_shared.hpp>
 #include <hpp/fcl/fwd.hh>
 #include <pinocchio/fwd.hpp>
 #include <pinocchio/multibody/fcl.hpp>
+
+// include boost after pinocchio
+#include <boost/make_shared.hpp>
 
 namespace hpp {
 namespace pinocchio {

--- a/include/hpp/pinocchio/shared-ptr.hh
+++ b/include/hpp/pinocchio/shared-ptr.hh
@@ -1,0 +1,20 @@
+#ifndef HPP_PINOCCHIO_SHARED_PTR_HH
+#define HPP_PINOCCHIO_SHARED_PTR_HH
+
+#include <boost/make_shared.hpp>
+#include <hpp/fcl/fwd.hh>
+#include <pinocchio/fwd.hpp>
+#include <pinocchio/multibody/fcl.hpp>
+
+namespace hpp {
+namespace pinocchio {
+
+std::shared_ptr<hpp::fcl::CollisionGeometry> as_std_shared_ptr(
+    boost::shared_ptr<hpp::fcl::CollisionGeometry> bp);
+
+boost::shared_ptr<hpp::fcl::CollisionGeometry> as_boost_shared_ptr(
+    std::shared_ptr<hpp::fcl::CollisionGeometry> bp);
+
+}  // namespace pinocchio
+}  // namespace hpp
+#endif  // HPP_PINOCCHIO_UTIL_HH

--- a/src/collision-object.cc
+++ b/src/collision-object.cc
@@ -32,6 +32,7 @@
 #include <hpp/pinocchio/device.hh>
 #include <hpp/pinocchio/joint-collection.hh>
 #include <hpp/pinocchio/joint.hh>
+#include <hpp/pinocchio/shared-ptr.hh>
 #include <pinocchio/multibody/geometry.hpp>
 #include <pinocchio/multibody/model.hpp>
 #include <pinocchio/spatial/fcl-pinocchio-conversions.hpp>
@@ -72,7 +73,7 @@ const ::pinocchio::GeometryObject& CollisionObject::pinocchio() const {
 }
 
 CollisionGeometryPtr_t CollisionObject::geometry() const {
-  return pinocchio().geometry;
+  return as_std_shared_ptr(pinocchio().geometry);
 }
 
 FclCollisionObjectPtr_t CollisionObject::fcl(GeomData& geomData) const {

--- a/src/device.cc
+++ b/src/device.cc
@@ -53,6 +53,7 @@
 #include <hpp/pinocchio/liegroup-space.hh>
 #include <hpp/pinocchio/liegroup.hh>
 #include <hpp/pinocchio/serialization.hh>
+#include <hpp/pinocchio/shared-ptr.hh>
 
 namespace hpp {
 namespace pinocchio {
@@ -504,7 +505,7 @@ void replaceGeometryByConvexHull(GeomModel& gmodel,
           dynamic_cast<fcl::BVHModelBase*>(go.geometry.get());
       assert(bvh != NULL);
       bvh->buildConvexHull(false, "Qx");
-      go.geometry = bvh->convex;
+      go.geometry = as_boost_shared_ptr(bvh->convex);
     }
   }
 #else

--- a/src/shared-ptr.cc
+++ b/src/shared-ptr.cc
@@ -1,0 +1,30 @@
+// convert CollisionGeometryPtr back and forth between pinocchio and hpp
+// ref. https://stackoverflow.com/a/71575543
+
+#include <hpp/pinocchio/shared-ptr.hh>
+
+namespace hpp {
+namespace pinocchio {
+
+std::shared_ptr<hpp::fcl::CollisionGeometry> as_std_shared_ptr(
+    boost::shared_ptr<hpp::fcl::CollisionGeometry> bp) {
+  if (!bp) return nullptr;
+  // a std shared pointer to boost shared ptr.  Yes.
+  auto pq = std::make_shared<boost::shared_ptr<hpp::fcl::CollisionGeometry>>(
+      std::move(bp));
+  // aliasing ctor.  Hide the double shared ptr.  Sneaky.
+  return std::shared_ptr<hpp::fcl::CollisionGeometry>(pq, pq.get()->get());
+}
+
+boost::shared_ptr<hpp::fcl::CollisionGeometry> as_boost_shared_ptr(
+    std::shared_ptr<hpp::fcl::CollisionGeometry> bp) {
+  if (!bp) return nullptr;
+  // a std shared pointer to boost shared ptr.  Yes.
+  auto pq = boost::make_shared<std::shared_ptr<hpp::fcl::CollisionGeometry>>(
+      std::move(bp));
+  // aliasing ctor.  Hide the double shared ptr.  Sneaky.
+  return boost::shared_ptr<hpp::fcl::CollisionGeometry>(pq, pq.get()->get());
+}
+
+}  // namespace pinocchio
+}  // namespace hpp

--- a/src/shared-ptr.cc
+++ b/src/shared-ptr.cc
@@ -6,24 +6,19 @@
 namespace hpp {
 namespace pinocchio {
 
-std::shared_ptr<hpp::fcl::CollisionGeometry> as_std_shared_ptr(
-    boost::shared_ptr<hpp::fcl::CollisionGeometry> bp) {
-  if (!bp) return nullptr;
-  // a std shared pointer to boost shared ptr.  Yes.
-  auto pq = std::make_shared<boost::shared_ptr<hpp::fcl::CollisionGeometry>>(
-      std::move(bp));
-  // aliasing ctor.  Hide the double shared ptr.  Sneaky.
-  return std::shared_ptr<hpp::fcl::CollisionGeometry>(pq, pq.get()->get());
+using std_ptr = std::shared_ptr<hpp::fcl::CollisionGeometry>;
+using boost_ptr = boost::shared_ptr<hpp::fcl::CollisionGeometry>;
+
+std_ptr as_std_shared_ptr(boost_ptr ptr) {
+  if (!ptr) return nullptr;
+  auto pq = std::make_shared<boost_ptr>(std::move(ptr));
+  return std_ptr(pq, pq.get()->get());
 }
 
-boost::shared_ptr<hpp::fcl::CollisionGeometry> as_boost_shared_ptr(
-    std::shared_ptr<hpp::fcl::CollisionGeometry> bp) {
-  if (!bp) return nullptr;
-  // a std shared pointer to boost shared ptr.  Yes.
-  auto pq = boost::make_shared<std::shared_ptr<hpp::fcl::CollisionGeometry>>(
-      std::move(bp));
-  // aliasing ctor.  Hide the double shared ptr.  Sneaky.
-  return boost::shared_ptr<hpp::fcl::CollisionGeometry>(pq, pq.get()->get());
+boost_ptr as_boost_shared_ptr(std_ptr ptr) {
+  if (!ptr) return nullptr;
+  auto pq = boost::make_shared<std_ptr>(std::move(ptr));
+  return boost_ptr(pq, pq.get()->get());
 }
 
 }  // namespace pinocchio


### PR DESCRIPTION
Hi,

Now that hpp-fcl use `std::shared_ptr<CollisionGeometry>` and pinocchio still wants `boost::shared_ptr<CollisionGeometry>`, I guess we have to convert back and forth here, because:

```cpp
…/src/collision-object.cc: In member function 'hpp::fcl::CollisionGeometryPtr_t hpp::pinocchio::CollisionObject::geometry() const':
…/src/collision-object.cc:68:26: error: could not convert '((const hpp::pinocchio::CollisionObject*)this)->hpp::pinocchio::CollisionObject::pinocchio().pinocchio::GeometryObject::geometry' from 'const CollisionGeometryPtr' {aka 'const boost::shared_ptr<hpp::fcl::CollisionGeometry>'} to 'hpp::fcl::CollisionGeometryPtr_t' {aka 'std::shared_ptr<hpp::fcl::CollisionGeometry>'}
     { return pinocchio().geometry; }
              ~~~~~~~~~~~~^~~~~~~~
                          |
                          const CollisionGeometryPtr {aka const boost::shared_ptr<hpp::fcl::CollisionGeometry>}
```

ref. https://stackoverflow.com/a/71575543

