### PR TITLE
[Liegroup] Remove overload of method isNormalized in SpecialEuclidean

### DIFF
--- a/include/hpp/pinocchio/liegroup-element.hh
+++ b/include/hpp/pinocchio/liegroup-element.hh
@@ -219,8 +219,9 @@ vector_t operator-(const LiegroupElementConstBase<vector_type1>& e1,
 /// \return whether the configuration is normalized
 ///
 template <typename vector_type>
-bool checkNormalized(const LiegroupElementConstBase<vector_type>& e1,
-                  const value_type& eps = PINOCCHIO_DEFAULT_QUATERNION_NORM_TOLERANCE_VALUE);
+bool checkNormalized(
+    const LiegroupElementConstBase<vector_type>& e1,
+    const value_type& eps = PINOCCHIO_DEFAULT_QUATERNION_NORM_TOLERANCE_VALUE);
 /// \}
 
 /// Compute the log as a tangent vector of a Lie group element

--- a/include/hpp/pinocchio/liegroup-element.hh
+++ b/include/hpp/pinocchio/liegroup-element.hh
@@ -31,6 +31,7 @@
 
 #include <hpp/pinocchio/deprecated.hh>
 #include <hpp/pinocchio/liegroup-space.hh>
+#include <pinocchio/math/quaternion.hpp>
 
 namespace hpp {
 namespace pinocchio {
@@ -203,13 +204,23 @@ LiegroupElement operator+(const LiegroupElementConstBase<vector_type>& e,
 /// Difference between two configurations
 ///
 /// \param e1, e2 elements of the Lie group,
-/// \return the velocity that integrated from e2 yiels e1
+/// \return the velocity that integrated from e2 yields e1
 ///
 /// By extension of the vector space case, we represent the integration
 /// of a constant velocity during unit time by an addition
 template <typename vector_type1, typename vector_type2>
 vector_t operator-(const LiegroupElementConstBase<vector_type1>& e1,
                    const LiegroupElementConstBase<vector_type2>& e2);
+
+/// Check if a configuration is normalized
+///
+/// \param e1 configuration to be checked
+/// \param eps the error threshold
+/// \return whether the configuration is normalized
+///
+template <typename vector_type>
+bool checkNormalized(const LiegroupElementConstBase<vector_type>& e1,
+                  const value_type& eps = PINOCCHIO_DEFAULT_QUATERNION_NORM_TOLERANCE_VALUE);
 /// \}
 
 /// Compute the log as a tangent vector of a Lie group element

--- a/include/hpp/pinocchio/liegroup/special-euclidean.hh
+++ b/include/hpp/pinocchio/liegroup/special-euclidean.hh
@@ -82,7 +82,6 @@ struct SpecialEuclideanOperation
     const_cast<Eigen::MatrixBase<JacobianOut_t>&>(Jout) =
         Jin.template bottomLeftCorner<3, 3>();
   }
-
 };
 }  // namespace liegroup
 }  // namespace pinocchio

--- a/include/hpp/pinocchio/liegroup/special-euclidean.hh
+++ b/include/hpp/pinocchio/liegroup/special-euclidean.hh
@@ -83,12 +83,6 @@ struct SpecialEuclideanOperation
         Jin.template bottomLeftCorner<3, 3>();
   }
 
-  template <class ConfigIn_t>
-  static bool isNormalized(const Eigen::MatrixBase<ConfigIn_t>& q,
-                           const value_type& eps) {
-    EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(ConfigIn_t, Base::ConfigVector_t);
-    return (std::abs(q.template tail<4>().norm() - 1) < eps);
-  }
 };
 }  // namespace liegroup
 }  // namespace pinocchio

--- a/src/is-normalized-visitor.hh
+++ b/src/is-normalized-visitor.hh
@@ -37,15 +37,12 @@ namespace liegroupType {
 /// Is Normalized visitor
 template <typename vector_type>
 struct IsNormalizedVisitor : public boost::static_visitor<> {
-  IsNormalizedVisitor(const vector_type& e1,
-                      const value_type& eps,
-                      bool& res)
+  IsNormalizedVisitor(const vector_type& e1, const value_type& eps, bool& res)
       : e1_(e1), iq_(0), eps_(eps), result(res) {}
   template <typename LiegroupType>
   void operator()(LiegroupType& op) {
     result &= op.isNormalized(
-                e1_.template segment<LiegroupType::NQ>(iq_, op.nq()),
-                eps_);
+        e1_.template segment<LiegroupType::NQ>(iq_, op.nq()), eps_);
 
     iq_ += op.nq();
   }

--- a/src/is-normalized-visitor.hh
+++ b/src/is-normalized-visitor.hh
@@ -1,5 +1,6 @@
-// Copyright (c) 2020, CNRS
-// Authors: Joseph Mirabel
+// Copyright (c) 2022, CNRS
+// Authors: Florent Lamiraux
+//          Le Quang Anh
 //
 
 // Redistribution and use in source and binary forms, with or without
@@ -26,36 +27,35 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
 // DAMAGE.
 
-#ifndef HPP_PINOCCHIO_SRC_VISITOR_INTERPOLATE_HH
-#define HPP_PINOCCHIO_SRC_VISITOR_INTERPOLATE_HH
+#ifndef HPP_PINOCCHIO_SRC_IS_NORMALIZED_VISITOR_HH
+#define HPP_PINOCCHIO_SRC_IS_NORMALIZED_VISITOR_HH
 
 namespace hpp {
 namespace pinocchio {
 namespace liegroupType {
-namespace visitor {
-/// Interpolate
-struct Interpolate : public boost::static_visitor<> {
-  Interpolate(const vectorIn_t& e1, const vectorIn_t& e2, value_type u,
-              vectorOut_t& er)
-      : e1_(e1), e2_(e2), u_(u), er_(er), iq_(0), iv_(0) {}
+
+/// Is Normalized visitor
+template <typename vector_type>
+struct IsNormalizedVisitor : public boost::static_visitor<> {
+  IsNormalizedVisitor(const vector_type& e1,
+                      const value_type& eps,
+                      bool& res)
+      : e1_(e1), iq_(0), eps_(eps), result(res) {}
   template <typename LiegroupType>
   void operator()(LiegroupType& op) {
-    op.interpolate(e1_.segment<LiegroupType::NQ>(iq_, op.nq()),
-                   e2_.segment<LiegroupType::NQ>(iq_, op.nq()), u_,
-                   er_.segment<LiegroupType::NQ>(iq_, op.nq()));
+    result &= op.isNormalized(
+                e1_.template segment<LiegroupType::NQ>(iq_, op.nq()),
+                eps_);
 
     iq_ += op.nq();
-    iv_ += op.nv();
   }
-  const vectorIn_t& e1_;
-  const vectorIn_t& e2_;
-  value_type u_;
-  vectorOut_t& er_;
-  size_type iq_, iv_;
-};  // struct Interpolate Visitor
-}  // namespace visitor
+  const vector_type& e1_;
+  size_type iq_;
+  const value_type& eps_;
+  bool& result;
+};  // struct IsNormalizedVisitor
 }  // namespace liegroupType
 }  // namespace pinocchio
 }  // namespace hpp
 
-#endif  // HPP_PINOCCHIO_SRC_VISITOR_INTERPOLATE_HH
+#endif  // HPP_PINOCCHIO_SRC_IS_NORMALIZED_VISITOR_HH

--- a/src/liegroup-element.cc
+++ b/src/liegroup-element.cc
@@ -36,6 +36,7 @@
 #include "../src/log-visitor.hh"
 #include "../src/size-visitor.hh"
 #include "../src/substraction-visitor.hh"
+#include "../src/is-normalized-visitor.hh"
 
 namespace hpp {
 namespace pinocchio {
@@ -111,6 +112,27 @@ template vector_t operator-(const LiegroupElementConstBase<vectorOut_t>& e1,
                             const LiegroupElementConstBase<vectorIn_t>& e2);
 template vector_t operator-(const LiegroupElementConstBase<vectorOut_t>& e1,
                             const LiegroupElementConstBase<vectorOut_t>& e2);
+
+template <typename vector_type>
+bool checkNormalized(const LiegroupElementConstBase<vector_type>& e1,
+                  const value_type& eps) {
+  bool result = true;
+
+  liegroupType::IsNormalizedVisitor<vector_type> isNormalizedvisitor(
+      e1.vector(), eps, result);
+  for (LiegroupTypes::const_iterator it = e1.space()->liegroupTypes().begin();
+       it != e1.space()->liegroupTypes().end(); ++it) {
+    boost::apply_visitor(isNormalizedvisitor, *it);
+  }
+  return result;
+}
+
+template bool checkNormalized(const LiegroupElementConstBase<vector_t>&e1,
+                              const value_type& eps);
+template bool checkNormalized(const LiegroupElementConstBase<vectorIn_t>&e1,
+                              const value_type& eps);
+template bool checkNormalized(const LiegroupElementConstBase<vectorOut_t>&e1,
+                              const value_type& eps);
 
 template <typename vector_type>
 vector_t log(const LiegroupElementConstBase<vector_type>& lge) {

--- a/src/liegroup-element.cc
+++ b/src/liegroup-element.cc
@@ -33,10 +33,10 @@
 #include <hpp/util/serialization.hh>
 
 #include "../src/addition-visitor.hh"
+#include "../src/is-normalized-visitor.hh"
 #include "../src/log-visitor.hh"
 #include "../src/size-visitor.hh"
 #include "../src/substraction-visitor.hh"
-#include "../src/is-normalized-visitor.hh"
 
 namespace hpp {
 namespace pinocchio {
@@ -115,7 +115,7 @@ template vector_t operator-(const LiegroupElementConstBase<vectorOut_t>& e1,
 
 template <typename vector_type>
 bool checkNormalized(const LiegroupElementConstBase<vector_type>& e1,
-                  const value_type& eps) {
+                     const value_type& eps) {
   bool result = true;
 
   liegroupType::IsNormalizedVisitor<vector_type> isNormalizedvisitor(
@@ -127,11 +127,11 @@ bool checkNormalized(const LiegroupElementConstBase<vector_type>& e1,
   return result;
 }
 
-template bool checkNormalized(const LiegroupElementConstBase<vector_t>&e1,
+template bool checkNormalized(const LiegroupElementConstBase<vector_t>& e1,
                               const value_type& eps);
-template bool checkNormalized(const LiegroupElementConstBase<vectorIn_t>&e1,
+template bool checkNormalized(const LiegroupElementConstBase<vectorIn_t>& e1,
                               const value_type& eps);
-template bool checkNormalized(const LiegroupElementConstBase<vectorOut_t>&e1,
+template bool checkNormalized(const LiegroupElementConstBase<vectorOut_t>& e1,
                               const value_type& eps);
 
 template <typename vector_type>

--- a/tests/tconfiguration.cc
+++ b/tests/tconfiguration.cc
@@ -45,6 +45,7 @@
 #include <hpp/pinocchio/joint.hh>
 #include <hpp/pinocchio/liegroup.hh>
 #include <hpp/pinocchio/simple-device.hh>
+#include <hpp/pinocchio/liegroup-element.hh>
 #include <pinocchio/algorithm/joint-configuration.hpp>
 
 using namespace hpp::pinocchio;
@@ -130,25 +131,37 @@ BOOST_AUTO_TEST_CASE(is_valid_configuration) {
 
   Configuration_t q = robot->neutralConfiguration();
   BOOST_CHECK(isNormalized(robot, q, eps));
+  LiegroupElementConstRef P1 (q, robot->configSpace());
+  BOOST_CHECK(checkNormalized(P1, eps));
 
   /// Set a quaternion of norm != 1
   q[3] = 1;
   q[4] = 1;
   BOOST_CHECK(!isNormalized(robot, q, eps));
+  LiegroupElementConstRef P2 (q, robot->configSpace());
+  BOOST_CHECK(!checkNormalized(P2, eps));
 
   robot = unittest::makeDevice(unittest::CarLike);
 
   q = robot->neutralConfiguration();
   BOOST_CHECK(isNormalized(robot, q, eps));
+  LiegroupElementConstRef P3 (q, robot->configSpace());
+  BOOST_CHECK(checkNormalized(P3, eps));
+
 
   /// Set a complex of norm != 1
   q.segment<2>(2) << 1, 1;
   BOOST_CHECK(!isNormalized(robot, q, eps));
+  LiegroupElementConstRef P4 (q, robot->configSpace());
+  BOOST_CHECK(!checkNormalized(P4, eps));
+
 
   robot = unittest::makeDevice(unittest::CarLike);
 
   q = robot->neutralConfiguration();
   BOOST_CHECK(isNormalized(robot, q, eps));
+  LiegroupElementConstRef P5 (q, robot->configSpace());
+  BOOST_CHECK(checkNormalized(P5, eps));
 }
 
 void test_difference_and_distance(DevicePtr_t robot) {

--- a/tests/tconfiguration.cc
+++ b/tests/tconfiguration.cc
@@ -43,9 +43,9 @@
 #include <hpp/pinocchio/humanoid-robot.hh>
 #include <hpp/pinocchio/joint-collection.hh>
 #include <hpp/pinocchio/joint.hh>
+#include <hpp/pinocchio/liegroup-element.hh>
 #include <hpp/pinocchio/liegroup.hh>
 #include <hpp/pinocchio/simple-device.hh>
-#include <hpp/pinocchio/liegroup-element.hh>
 #include <pinocchio/algorithm/joint-configuration.hpp>
 
 using namespace hpp::pinocchio;
@@ -131,36 +131,34 @@ BOOST_AUTO_TEST_CASE(is_valid_configuration) {
 
   Configuration_t q = robot->neutralConfiguration();
   BOOST_CHECK(isNormalized(robot, q, eps));
-  LiegroupElementConstRef P1 (q, robot->configSpace());
+  LiegroupElementConstRef P1(q, robot->configSpace());
   BOOST_CHECK(checkNormalized(P1, eps));
 
   /// Set a quaternion of norm != 1
   q[3] = 1;
   q[4] = 1;
   BOOST_CHECK(!isNormalized(robot, q, eps));
-  LiegroupElementConstRef P2 (q, robot->configSpace());
+  LiegroupElementConstRef P2(q, robot->configSpace());
   BOOST_CHECK(!checkNormalized(P2, eps));
 
   robot = unittest::makeDevice(unittest::CarLike);
 
   q = robot->neutralConfiguration();
   BOOST_CHECK(isNormalized(robot, q, eps));
-  LiegroupElementConstRef P3 (q, robot->configSpace());
+  LiegroupElementConstRef P3(q, robot->configSpace());
   BOOST_CHECK(checkNormalized(P3, eps));
-
 
   /// Set a complex of norm != 1
   q.segment<2>(2) << 1, 1;
   BOOST_CHECK(!isNormalized(robot, q, eps));
-  LiegroupElementConstRef P4 (q, robot->configSpace());
+  LiegroupElementConstRef P4(q, robot->configSpace());
   BOOST_CHECK(!checkNormalized(P4, eps));
-
 
   robot = unittest::makeDevice(unittest::CarLike);
 
   q = robot->neutralConfiguration();
   BOOST_CHECK(isNormalized(robot, q, eps));
-  LiegroupElementConstRef P5 (q, robot->configSpace());
+  LiegroupElementConstRef P5(q, robot->configSpace());
   BOOST_CHECK(checkNormalized(P5, eps));
 }
 


### PR DESCRIPTION
This method was wrong for SO(2) and is already implemented in pinocchio.