### PR TITLE
Update liegroup.hh to match new logic of cmake JRL submodule of deprecated

### DIFF
--- a/include/hpp/pinocchio/liegroup.hh
+++ b/include/hpp/pinocchio/liegroup.hh
@@ -54,7 +54,7 @@ struct RnxSOnLieGroupMap {
   struct operation {};
 };
 /// \deprecated Use RnxSOnLieGroupMap
-typedef HPP_PINOCCHIO_DEPRECATED RnxSOnLieGroupMap LieGroupTpl;
+HPP_PINOCCHIO_DEPRECATED typedef RnxSOnLieGroupMap LieGroupTpl;
 
 /// This class maps at compile time a joint type to a lie group type.
 ///


### PR DESCRIPTION
It follows the reponse to the issue raise in cmake jrl submodule https://github.com/jrl-umi3218/jrl-cmakemodules/issues/563#issuecomment-1308090359