### PR TITLE
Replace boost::shared_ptr by std::shared_ptr.

### DIFF
--- a/include/hpp/pinocchio/fwd.hh
+++ b/include/hpp/pinocchio/fwd.hh
@@ -38,7 +38,6 @@
 #include <hpp/fcl/collision_data.h>  // DistanceResult
 
 #include <Eigen/Core>
-#include <boost/shared_ptr.hpp>  // For the CollisionGeometry discrepancy
 #include <hpp/fcl/fwd.hh>
 #include <hpp/util/pointer.hh>
 #include <pinocchio/multibody/fwd.hpp>
@@ -116,7 +115,7 @@ using fcl::CollisionGeometry;
 // pinocchio headers. typedef decltype(GeomModel::geometry)
 // CollisionGeometryPtr_t;
 // TODO going as dirty as this.
-typedef boost::shared_ptr<CollisionGeometry> CollisionGeometryPtr_t;
+typedef shared_ptr<CollisionGeometry> CollisionGeometryPtr_t;
 typedef fcl::CollisionObject FclCollisionObject;
 typedef fcl::CollisionObject* FclCollisionObjectPtr_t;
 typedef const fcl::CollisionObject* FclConstCollisionObjectPtr_t;

--- a/include/hpp/pinocchio/fwd.hh
+++ b/include/hpp/pinocchio/fwd.hh
@@ -107,14 +107,7 @@ struct ObjectVector;
 typedef ObjectVector ObjectVector_t;
 typedef shared_ptr<Body> BodyPtr_t;
 typedef shared_ptr<const Body> BodyConstPtr_t;
-// typedef std::vector<BodyPtr_t> BodyVector_t;
 using fcl::CollisionGeometry;
-// TODO the line below does not work because of a discrepancy between hpp-fcl
-// and pinocchio using fcl::CollisionGeometryPtr_t;
-// TODO this would be a possible fix but that requires to always include
-// pinocchio headers. typedef decltype(GeomModel::geometry)
-// CollisionGeometryPtr_t;
-// TODO going as dirty as this.
 typedef shared_ptr<CollisionGeometry> CollisionGeometryPtr_t;
 typedef fcl::CollisionObject FclCollisionObject;
 typedef fcl::CollisionObject* FclCollisionObjectPtr_t;


### PR DESCRIPTION
Update to recent modification in pinocchio allowing to use std::shared_ptr.