### PR TITLE
Partially Revert "make code robust to boost/std shared_ptr for fcl object"

### DIFF
--- a/include/hpp/pinocchio/collision-object.hh
+++ b/include/hpp/pinocchio/collision-object.hh
@@ -71,6 +71,18 @@ class HPP_PINOCCHIO_DLLAPI CollisionObject {
   /// Access to fcl object
   CollisionGeometryPtr_t geometry() const;
 
+  /// Access to fcl object
+  FclConstCollisionObjectPtr_t fcl(const GeomData& data) const;
+  FclCollisionObjectPtr_t fcl(GeomData& data) const;
+  FclConstCollisionObjectPtr_t fcl() const;
+  FclCollisionObjectPtr_t fcl();
+
+  /// Returns the FCL collision object.
+  /// \param d Ignored if this object represents an obstacle.
+  ///          Otherwise, a DeviceData for the internal device.
+  FclCollisionObjectPtr_t fcl(DeviceData& d) const;
+  FclConstCollisionObjectPtr_t fcl(const DeviceData& d) const;
+
   /// Get joint index
   const JointIndex& jointIndex() const { return jointIndex_; }
 

--- a/src/collision-object.cc
+++ b/src/collision-object.cc
@@ -75,6 +75,32 @@ CollisionGeometryPtr_t CollisionObject::geometry() const {
   return pinocchio().geometry;
 }
 
+FclCollisionObjectPtr_t CollisionObject::fcl(GeomData& geomData) const {
+  return FclCollisionObjectPtr_t(new FclCollisionObject(
+      geometry(), toFclTransform3f(geomData.oMg[geomInModelIndex])));
+}
+
+FclConstCollisionObjectPtr_t CollisionObject::fcl(
+    const GeomData& geomData) const {
+  return FclCollisionObjectPtr_t(new FclCollisionObject(
+      geometry(), toFclTransform3f(geomData.oMg[geomInModelIndex])));
+}
+
+FclConstCollisionObjectPtr_t CollisionObject::fcl() const {
+  return fcl(geomData());
+}
+FclCollisionObjectPtr_t CollisionObject::fcl() { return fcl(geomData()); }
+
+FclCollisionObjectPtr_t CollisionObject::fcl(DeviceData& d) const {
+  return FclCollisionObjectPtr_t(new FclCollisionObject(
+      geometry(), toFclTransform3f(geomData(d).oMg[geomInModelIndex])));
+}
+
+FclConstCollisionObjectPtr_t CollisionObject::fcl(const DeviceData& d) const {
+  return FclCollisionObjectPtr_t(new FclCollisionObject(
+      geometry(), toFclTransform3f(geomData(d).oMg[geomInModelIndex])));
+}
+
 JointPtr_t CollisionObject::joint() {
   if (!devicePtr) return JointPtr_t();
   return Joint::create(devicePtr, jointIndex_);

--- a/src/device.cc
+++ b/src/device.cc
@@ -503,13 +503,8 @@ void replaceGeometryByConvexHull(GeomModel& gmodel,
       fcl::BVHModelBase* bvh =
           dynamic_cast<fcl::BVHModelBase*>(go.geometry.get());
       assert(bvh != NULL);
-      // TODO The following can't work because bvh->convex is a std::shared_ptr
-      // while go.geometry is a boost::shared_ptr
-      // bvh->buildConvexHull(false, "Qx");
-      // go.geometry = bvh->convex;
-      fcl::ConvexBase* convex = fcl::ConvexBase::convexHull(
-          bvh->vertices, bvh->num_vertices, false, "Qx");
-      go.geometry.reset(convex);
+      bvh->buildConvexHull(false, "Qx");
+      go.geometry = bvh->convex;
     }
   }
 #else


### PR DESCRIPTION
This partially reverts commit d32674f35879a02b3072b31a1a8f8cc2ad775b49 : 

since we can now have std shared_ptr everywhere, there is no need to break the API