### PR TITLE
Remove computation flag and pass it to Device::computeForwardKinematics

### DIFF
--- a/include/hpp/pinocchio/device-data.hh
+++ b/include/hpp/pinocchio/device-data.hh
@@ -53,12 +53,14 @@ struct DeviceData {
   DeviceData(const DeviceData& other);
 
   inline void invalidate() {
-    upToDate_ = false;
+    dataUpToDate_ = 0;
     frameUpToDate_ = false;
     geomUpToDate_ = false;
   }
 
-  void computeForwardKinematics(const ModelPtr_t& m);
+  /// \param flag to customise the computation. This should be a bitwise OR
+  ///        between Computation_t values.
+  void computeForwardKinematics(const ModelPtr_t& m, int flag);
   void computeFramesForwardKinematics(const ModelPtr_t& m);
   void updateGeometryPlacements(const ModelPtr_t& m, const GeomModelPtr_t& gm);
 
@@ -69,7 +71,8 @@ struct DeviceData {
   Configuration_t currentConfiguration_;
   vector_t currentVelocity_;
   vector_t currentAcceleration_;
-  bool upToDate_, frameUpToDate_, geomUpToDate_;
+  int dataUpToDate_;
+  bool frameUpToDate_, geomUpToDate_;
   Computation_t computationFlag_;
   DeviceWkPtr_t devicePtr_;
 

--- a/include/hpp/pinocchio/device-data.hh
+++ b/include/hpp/pinocchio/device-data.hh
@@ -73,7 +73,6 @@ struct DeviceData {
   vector_t currentAcceleration_;
   int dataUpToDate_;
   bool frameUpToDate_, geomUpToDate_;
-  Computation_t computationFlag_;
   DeviceWkPtr_t devicePtr_;
 
   /// Temporary variable to avoid dynamic allocation

--- a/include/hpp/pinocchio/device-sync.hh
+++ b/include/hpp/pinocchio/device-sync.hh
@@ -31,6 +31,7 @@
 #ifndef HPP_PINOCCHIO_DEVICE_SYNC_HH
 #define HPP_PINOCCHIO_DEVICE_SYNC_HH
 
+#include <hpp/pinocchio/deprecated.hh>
 #include <hpp/pinocchio/device-data.hh>
 #include <hpp/pinocchio/fwd.hh>
 
@@ -148,18 +149,21 @@ class HPP_PINOCCHIO_DLLAPI AbstractDevice {
   /// \name Forward kinematics
   /// \{
 
-  /// Select computation
-  /// Optimize computation time by selecting only necessary values in
-  /// method computeForwardKinematics.
-  void controlComputation(const Computation_t& flag);
-  /// Get computation flag
-  Computation_t computationFlag() const { return d().computationFlag_; }
+  /// \deprecated Use computeForwardKinematics(Computation_t) instead to select
+  /// what should be computed.
+  void controlComputation(const Computation_t& flag) HPP_PINOCCHIO_DEPRECATED {}
+  /// \deprecated returns COMPUTE_ALL
+  Computation_t computationFlag() const HPP_PINOCCHIO_DEPRECATED {
+    return COMPUTE_ALL;
+  }
   /// Compute forward kinematics computing everything
-  void computeForwardKinematics() { d().computeForwardKinematics(modelPtr(), COMPUTE_ALL); }
+  void computeForwardKinematics() { computeForwardKinematics(COMPUTE_ALL); }
   /// Compute forward kinematics with custom computation flag
   /// \param flag to customise the computation. This should be a bitwise OR
   ///        between Computation_t values.
-  void computeForwardKinematics(int flag) { d().computeForwardKinematics(modelPtr(), flag); }
+  void computeForwardKinematics(int flag) {
+    d().computeForwardKinematics(modelPtr(), flag);
+  }
   /// Compute frame forward kinematics
   /// \note call AbstractDevice::computeForwardKinematics.
   void computeFramesForwardKinematics() {

--- a/include/hpp/pinocchio/device-sync.hh
+++ b/include/hpp/pinocchio/device-sync.hh
@@ -151,11 +151,15 @@ class HPP_PINOCCHIO_DLLAPI AbstractDevice {
   /// Select computation
   /// Optimize computation time by selecting only necessary values in
   /// method computeForwardKinematics.
-  virtual void controlComputation(const Computation_t& flag);
+  void controlComputation(const Computation_t& flag);
   /// Get computation flag
   Computation_t computationFlag() const { return d().computationFlag_; }
-  /// Compute forward kinematics
-  void computeForwardKinematics() { d().computeForwardKinematics(modelPtr()); }
+  /// Compute forward kinematics computing everything
+  void computeForwardKinematics() { d().computeForwardKinematics(modelPtr(), COMPUTE_ALL); }
+  /// Compute forward kinematics with custom computation flag
+  /// \param flag to customise the computation. This should be a bitwise OR
+  ///        between Computation_t values.
+  void computeForwardKinematics(int flag) { d().computeForwardKinematics(modelPtr(), flag); }
   /// Compute frame forward kinematics
   /// \note call AbstractDevice::computeForwardKinematics.
   void computeFramesForwardKinematics() {
@@ -190,7 +194,7 @@ class HPP_PINOCCHIO_DLLAPI AbstractDevice {
 /// // Acquires a lock on the device.
 /// DeviceSync deviceSync (device);
 /// deviceSync.currentConfiguration(q);
-/// deviceSync.computeForwardKinematics();
+/// deviceSync.computeForwardKinematics(JOINT_POSITION | JACOBIAN);
 ///
 /// JointPtr_t joint = ...;
 /// joint->currentTransformation (deviceSync.d());

--- a/include/hpp/pinocchio/device.hh
+++ b/include/hpp/pinocchio/device.hh
@@ -314,8 +314,6 @@ class HPP_PINOCCHIO_DLLAPI Device : public AbstractDevice {
   /// - sum all the BB obtained.
   fcl::AABB computeAABB() const;
 
-  void controlComputation(const Computation_t& flag);
-
  protected:
   /// \brief Constructor
   Device(const std::string& name);

--- a/src/device-data.cc
+++ b/src/device-data.cc
@@ -39,8 +39,7 @@
 namespace hpp {
 namespace pinocchio {
 
-DeviceData::DeviceData()
-    : computationFlag_(Computation_t(JOINT_POSITION | JACOBIAN)) {
+DeviceData::DeviceData() {
   invalidate();
 }
 
@@ -53,7 +52,6 @@ DeviceData::DeviceData(const DeviceData& other)
       dataUpToDate_(other.dataUpToDate_),
       frameUpToDate_(other.frameUpToDate_),
       geomUpToDate_(other.geomUpToDate_),
-      computationFlag_(other.computationFlag_),
       devicePtr_(),
       modelConf_(other.modelConf_.size()),
       jointJacobians_(other.jointJacobians_.size()) {}

--- a/src/device-data.cc
+++ b/src/device-data.cc
@@ -39,9 +39,7 @@
 namespace hpp {
 namespace pinocchio {
 
-DeviceData::DeviceData() {
-  invalidate();
-}
+DeviceData::DeviceData() { invalidate(); }
 
 DeviceData::DeviceData(const DeviceData& other)
     : data_(new Data(*other.data_)),
@@ -68,7 +66,6 @@ void checkComputationFlag(int flag) {
   assert((flag & JOINT_POSITION) || (!(flag & COM)));
   // jacobian IMPLIES position
   assert((flag & JOINT_POSITION) || (!(flag & JACOBIAN)));
-
 }
 
 constexpr int FK_ACC = JOINT_POSITION | VELOCITY | ACCELERATION;

--- a/src/device-sync.cc
+++ b/src/device-sync.cc
@@ -79,13 +79,6 @@ const ComJacobian_t& AbstractDevice::jacobianCenterOfMass() const {
   return data().Jcom;
 }
 
-void AbstractDevice::controlComputation(const Computation_t& flag) {
-  if (d().computationFlag_ != flag) {
-    d().computationFlag_ = flag;
-    d().invalidate();
-  }
-}
-
 AbstractDevice::AbstractDevice()
     : model_(new Model()), geomModel_(new GeomModel()) {}
 

--- a/src/device.cc
+++ b/src/device.cc
@@ -176,15 +176,6 @@ void Device::removeJoints(const std::vector<std::string>& jointNames,
   numberDeviceData(numberDeviceData());
 }
 
-void Device::controlComputation(const Computation_t& flag) {
-  AbstractDevice::controlComputation(flag);
-  // TODO this should not be done in controlComputation
-  // It should be done in another function (like controlComputations)
-  // as it might be a desired behaviour to have different computation options
-  // in different DeviceData.
-  numberDeviceData(numberDeviceData());
-}
-
 /* ---------------------------------------------------------------------- */
 /* --- JOINT ------------------------------------------------------------ */
 /* ---------------------------------------------------------------------- */

--- a/src/simple-device.cc
+++ b/src/simple-device.cc
@@ -101,7 +101,7 @@ DevicePtr_t humanoidSimple(const std::string& name, Computation_t compFlags) {
   robot->createGeomData();
   robot->controlComputation(compFlags);
   robot->currentConfiguration(robot->neutralConfiguration());
-  robot->computeForwardKinematics();
+  robot->computeForwardKinematics(compFlags);
 
   const value_type max = std::numeric_limits<value_type>::max();
   const value_type min = -std::numeric_limits<value_type>::max();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -49,9 +49,9 @@ endmacro(ADD_TESTCASE)
 # --- LIST OF TESTS ------------------------------------------------------------
 # --- LIST OF TESTS ------------------------------------------------------------
 
-if(ROMEO_DESCRIPTION_FOUND)
+if(example-robot-data_FOUND)
   add_testcase(frame)
-endif(ROMEO_DESCRIPTION_FOUND)
+endif(example-robot-data_FOUND)
 
 add_testcase(tconfiguration)
 add_testcase(device)

--- a/tests/device-sync.cc
+++ b/tests/device-sync.cc
@@ -83,7 +83,7 @@ typedef ::pinocchio::container::aligned_vector<SE3> SE3Vector_t;
 void compute_forward_kinematics(DevicePtr_t& device, const Configuration_t& q,
                                 SE3Vector_t& res) {
   device->currentConfiguration(q);
-  device->computeForwardKinematics();
+  device->computeForwardKinematics(JOINT_POSITION);
 
   res = device->data().oMi;
 }
@@ -93,7 +93,7 @@ void compute_forward_kinematics_thread_safe(DevicePtr_t& device,
                                             SE3Vector_t& res) {
   DeviceSync sync(device);
   sync.currentConfiguration(q);
-  sync.computeForwardKinematics();
+  sync.computeForwardKinematics(JOINT_POSITION);
 
   res = sync.data().oMi;
 }

--- a/tests/frame.cc
+++ b/tests/frame.cc
@@ -42,8 +42,7 @@
 using namespace hpp::pinocchio;
 
 typedef std::vector<std::string> Strings_t;
-void check_children(const Model& model, Frame& f,
-                    Strings_t expected_children) {
+void check_children(const Model& model, Frame& f, Strings_t expected_children) {
   const std::vector<FrameIndex>& children = f.children();
   BOOST_CHECK_EQUAL(children.size(), expected_children.size());
   for (std::size_t i = 0; i < children.size(); ++i) {

--- a/tests/frame.cc
+++ b/tests/frame.cc
@@ -69,7 +69,7 @@ BOOST_AUTO_TEST_CASE(frame) {
   DevicePtr_t pinocchio = hppPinocchio();
   Configuration_t q = pinocchio->neutralConfiguration();
   pinocchio->currentConfiguration(q);
-  pinocchio->computeForwardKinematics();
+  pinocchio->computeForwardKinematics(JOINT_POSITION);
 
   Frame root = pinocchio->getFrameByName("root_joint");
   Frame waist = pinocchio->getFrameByName("waist");
@@ -110,7 +110,7 @@ BOOST_AUTO_TEST_CASE(frame) {
 
   Transform3f shift = Transform3f::Random();
   waist.positionInParentFrame(shift);
-  pinocchio->computeForwardKinematics();
+  pinocchio->computeForwardKinematics()JOINT_POSITION;
 
   CHECK_TRANSFORM(ImuTorsoAcc_F.positionInParentFrame(), ImuTorsoAcc_M);
   CHECK_TRANSFORM(ImuTorsoGyr_F.positionInParentFrame(), ImuTorsoGyr_M);


### PR DESCRIPTION
The global computation flag makes it difficult to use the device in a multithreaded environment.

Instead, in this PR, I make the flag an argument of `computeForwardKinematics` and let callers request specific calculations.
Calling `computeForwardKinematics` without arguments computes everything so the PR should be backward compatible (at the cost of a probably negligible increase in computation time).

PRs on other hpp packages:
- https://github.com/humanoid-path-planner/hpp-constraints/pull/187
- https://github.com/humanoid-path-planner/hpp-core/pull/327
- https://github.com/humanoid-path-planner/hpp-corbaserver/pull/217
- https://github.com/humanoid-path-planner/hpp-manipulation-corba/pull/158