### PR TITLE
Update to pinocchio 3

### DIFF
--- a/include/hpp/pinocchio/joint-collection.hh
+++ b/include/hpp/pinocchio/joint-collection.hh
@@ -37,10 +37,10 @@
 #include "pinocchio/multibody/joint/fwd.hpp"
 #include "pinocchio/multibody/joint/joint-free-flyer.hpp"
 #include "pinocchio/multibody/joint/joint-planar.hpp"
+#include "pinocchio/multibody/joint/joint-prismatic-unaligned.hpp"
 #include "pinocchio/multibody/joint/joint-prismatic.hpp"
 #include "pinocchio/multibody/joint/joint-revolute-unaligned.hpp"
 #include "pinocchio/multibody/joint/joint-revolute-unbounded-unaligned.hpp"
-#include "pinocchio/multibody/joint/joint-prismatic-unaligned.hpp"
 #include "pinocchio/multibody/joint/joint-revolute-unbounded.hpp"
 #include "pinocchio/multibody/joint/joint-revolute.hpp"
 // #include "pinocchio/multibody/joint/joint-spherical-ZYX.hpp"
@@ -106,16 +106,13 @@ struct JointCollectionTpl {
 
   typedef boost::variant<
       JointModelRX, JointModelRY, JointModelRZ, JointModelFreeFlyer,
-      JointModelPlanar, JointModelRevoluteUnaligned
-      ,
+      JointModelPlanar, JointModelRevoluteUnaligned,
 #if PINOCCHIO_VERSION_AT_LEAST(3, 0, 0)
-      JointModelSpherical,
-      JointModelSphericalZYX,
+      JointModelSpherical, JointModelSphericalZYX,
 #endif
-      JointModelRevoluteUnboundedUnaligned
-      ,
-      JointModelPX, JointModelPY, JointModelPZ, JointModelPrismaticUnaligned,
-      JointModelTranslation, JointModelRUBX, JointModelRUBY, JointModelRUBZ>
+      JointModelRevoluteUnboundedUnaligned, JointModelPX, JointModelPY,
+      JointModelPZ, JointModelPrismaticUnaligned, JointModelTranslation,
+      JointModelRUBX, JointModelRUBY, JointModelRUBZ>
       JointModelVariant;
 
   // Joint Revolute
@@ -175,16 +172,13 @@ struct JointCollectionTpl {
   typedef boost::variant<
       //    JointDataVoid
       JointDataRX, JointDataRY, JointDataRZ, JointDataFreeFlyer,
-      JointDataPlanar, JointDataRevoluteUnaligned
-      ,
+      JointDataPlanar, JointDataRevoluteUnaligned,
 #if PINOCCHIO_VERSION_AT_LEAST(3, 0, 0)
-      JointDataSpherical,
-      JointDataSphericalZYX,
+      JointDataSpherical, JointDataSphericalZYX,
 #endif
-      JointDataRevoluteUnboundedUnaligned
-      ,
-      JointDataPX, JointDataPY, JointDataPZ, JointDataPrismaticUnaligned,
-      JointDataTranslation, JointDataRUBX, JointDataRUBY, JointDataRUBZ>
+      JointDataRevoluteUnboundedUnaligned, JointDataPX, JointDataPY,
+      JointDataPZ, JointDataPrismaticUnaligned, JointDataTranslation,
+      JointDataRUBX, JointDataRUBY, JointDataRUBZ>
       JointDataVariant;
 };
 

--- a/include/hpp/pinocchio/joint-collection.hh
+++ b/include/hpp/pinocchio/joint-collection.hh
@@ -39,9 +39,7 @@
 #include "pinocchio/multibody/joint/joint-planar.hpp"
 #include "pinocchio/multibody/joint/joint-prismatic.hpp"
 #include "pinocchio/multibody/joint/joint-revolute-unaligned.hpp"
-#if PINOCCHIO_VERSION_AT_LEAST(2, 1, 5)
 #include "pinocchio/multibody/joint/joint-revolute-unbounded-unaligned.hpp"
-#endif
 #include "pinocchio/multibody/joint/joint-prismatic-unaligned.hpp"
 #include "pinocchio/multibody/joint/joint-revolute-unbounded.hpp"
 #include "pinocchio/multibody/joint/joint-revolute.hpp"
@@ -74,11 +72,9 @@ struct JointCollectionTpl {
   typedef ::pinocchio::JointModelRevoluteUnboundedTpl<Scalar, Options, 2>
       JointModelRUBZ;
 
-#if PINOCCHIO_VERSION_AT_LEAST(2, 1, 5)
   // Joint Revolute Unbounded Unaligned
   typedef ::pinocchio::JointModelRevoluteUnboundedUnalignedTpl<Scalar, Options>
       JointModelRevoluteUnboundedUnaligned;
-#endif
 
   // Joint Prismatic
   typedef ::pinocchio::JointModelPrismaticTpl<Scalar, Options, 0> JointModelPX;
@@ -108,19 +104,15 @@ struct JointCollectionTpl {
   // Joint Planar
   typedef ::pinocchio::JointModelPlanarTpl<Scalar, Options> JointModelPlanar;
 
-  // Joint Composite
-  typedef ::pinocchio::JointModelCompositeTpl<Scalar, Options,
-                                              pinocchio::JointCollectionTpl>
-      JointModelComposite;
-
   typedef boost::variant<
-      //    JointModelVoid,
       JointModelRX, JointModelRY, JointModelRZ, JointModelFreeFlyer,
       JointModelPlanar, JointModelRevoluteUnaligned
-#if PINOCCHIO_VERSION_AT_LEAST(2, 1, 5)
       ,
-      JointModelRevoluteUnboundedUnaligned
+#if PINOCCHIO_VERSION_AT_LEAST(3, 0, 0)
+      JointModelSpherical,
+      JointModelSphericalZYX,
 #endif
+      JointModelRevoluteUnboundedUnaligned
       ,
       JointModelPX, JointModelPY, JointModelPZ, JointModelPrismaticUnaligned,
       JointModelTranslation, JointModelRUBX, JointModelRUBY, JointModelRUBZ>
@@ -143,11 +135,9 @@ struct JointCollectionTpl {
   typedef ::pinocchio::JointDataRevoluteUnboundedTpl<Scalar, Options, 2>
       JointDataRUBZ;
 
-#if PINOCCHIO_VERSION_AT_LEAST(2, 1, 5)
   // Joint Revolute Unbounded Unaligned
   typedef ::pinocchio::JointDataRevoluteUnboundedUnalignedTpl<Scalar, Options>
       JointDataRevoluteUnboundedUnaligned;
-#endif
 
   // Joint Prismatic
   typedef ::pinocchio::JointDataPrismaticTpl<Scalar, Options, 0> JointDataPX;
@@ -186,10 +176,12 @@ struct JointCollectionTpl {
       //    JointDataVoid
       JointDataRX, JointDataRY, JointDataRZ, JointDataFreeFlyer,
       JointDataPlanar, JointDataRevoluteUnaligned
-#if PINOCCHIO_VERSION_AT_LEAST(2, 1, 5)
       ,
-      JointDataRevoluteUnboundedUnaligned
+#if PINOCCHIO_VERSION_AT_LEAST(3, 0, 0)
+      JointDataSpherical,
+      JointDataSphericalZYX,
 #endif
+      JointDataRevoluteUnboundedUnaligned
       ,
       JointDataPX, JointDataPY, JointDataPZ, JointDataPrismaticUnaligned,
       JointDataTranslation, JointDataRUBX, JointDataRUBY, JointDataRUBZ>

--- a/include/hpp/pinocchio/liegroup.hh
+++ b/include/hpp/pinocchio/liegroup.hh
@@ -29,13 +29,12 @@
 #ifndef HPP_PINOCCHIO_LIEGROUP_HH
 #define HPP_PINOCCHIO_LIEGROUP_HH
 
-#include <pinocchio/multibody/joint/joints.hpp>
-
 #include <hpp/pinocchio/deprecated.hh>
 #include <hpp/pinocchio/liegroup/cartesian-product.hh>
 #include <hpp/pinocchio/liegroup/special-euclidean.hh>
 #include <hpp/pinocchio/liegroup/special-orthogonal.hh>
 #include <hpp/pinocchio/liegroup/vector-space.hh>
+#include <pinocchio/multibody/joint/joints.hpp>
 
 namespace hpp {
 namespace pinocchio {

--- a/include/hpp/pinocchio/liegroup.hh
+++ b/include/hpp/pinocchio/liegroup.hh
@@ -29,8 +29,7 @@
 #ifndef HPP_PINOCCHIO_LIEGROUP_HH
 #define HPP_PINOCCHIO_LIEGROUP_HH
 
-#include <pinocchio/multibody/joint/fwd.hpp>
-// #include <pinocchio/multibody/liegroup/liegroup.hpp>
+#include <pinocchio/multibody/joint/joints.hpp>
 
 #include <hpp/pinocchio/deprecated.hh>
 #include <hpp/pinocchio/liegroup/cartesian-product.hh>
@@ -40,8 +39,6 @@
 
 namespace hpp {
 namespace pinocchio {
-typedef ::pinocchio::JointModelCompositeTpl<value_type, 0, JointCollectionTpl>
-    JointModelComposite;
 
 /// This class maps at compile time a joint type to a lie group type.
 ///
@@ -84,13 +81,11 @@ struct RnxSOnLieGroupMap::operation<
     ::pinocchio::JointModelRevoluteUnalignedTpl<Scalar, Options> > {
   typedef liegroup::VectorSpaceOperation<1, true> type;
 };
-#if PINOCCHIO_VERSION_AT_LEAST(2, 1, 5)
 template <typename Scalar, int Options>
 struct RnxSOnLieGroupMap::operation<
     ::pinocchio::JointModelRevoluteUnboundedUnalignedTpl<Scalar, Options> > {
   typedef liegroup::SpecialOrthogonalOperation<2> type;
 };
-#endif
 
 // JointModelPrismaticTpl, JointModelPrismaticUnaligned, JointModelTranslation
 template <typename Scalar, int Options, int Axis>
@@ -158,13 +153,11 @@ struct DefaultLieGroupMap::operation<
     ::pinocchio::JointModelRevoluteUnalignedTpl<Scalar, Options> > {
   typedef liegroup::VectorSpaceOperation<1, true> type;
 };
-#if PINOCCHIO_VERSION_AT_LEAST(2, 1, 5)
 template <typename Scalar, int Options>
 struct DefaultLieGroupMap::operation<
     ::pinocchio::JointModelRevoluteUnboundedUnalignedTpl<Scalar, Options> > {
   typedef liegroup::SpecialOrthogonalOperation<2> type;
 };
-#endif
 
 // JointModelPrismaticTpl, JointModelPrismaticUnaligned, JointModelTranslation
 template <typename Scalar, int Options, int Axis>
@@ -206,6 +199,7 @@ struct DefaultLieGroupMap::operation<
     ::pinocchio::JointModelPlanarTpl<Scalar, Options> > {
   typedef liegroup::SpecialEuclideanOperation<2> type;
 };
+
 /// \endcond
 }  // namespace pinocchio
 }  // namespace hpp

--- a/src/configuration.cc
+++ b/src/configuration.cc
@@ -225,14 +225,6 @@ struct IsNormalizedStep
   }
 };
 
-template <>
-void IsNormalizedStep::algo<JointModelComposite>(
-    const ::pinocchio::JointModelBase<JointModelComposite>& jmodel,
-    ConfigurationIn_t q, const value_type& eps, bool& ret) {
-  ::pinocchio::details::Dispatch<IsNormalizedStep>::run(
-      jmodel.derived(), IsNormalizedStep::ArgsType(q, eps, ret));
-}
-
 bool isNormalized(const DevicePtr_t& robot, ConfigurationIn_t q,
                   const value_type& eps) {
   bool ret = true;

--- a/src/device.cc
+++ b/src/device.cc
@@ -388,13 +388,13 @@ struct AABBStep : public ::pinocchio::fusion::JointUnaryVisitorBase<AABBStep> {
         jmodel.jointConfigSelector(model.lowerPositionLimit)
             .template head<LG_t::NT>();
     jmodel.calc(data, q);
-    vector3_t min = data.M.translation();
+    vector3_t min = data.M_accessor().translation();
     // Set configuration to upper bound.
     jmodel.jointConfigSelector(q).template head<LG_t::NT>() =
         jmodel.jointConfigSelector(model.upperPositionLimit)
             .template head<LG_t::NT>();
     jmodel.calc(data, q);
-    vector3_t max = data.M.translation();
+    vector3_t max = data.M_accessor().translation();
 
     // This should not be required as it should be done in
     // AABB::operator+=(Vec3f) for(int i = 0; i < 3; ++i) { if (min[i] > max[i])
@@ -409,24 +409,6 @@ struct AABBStep : public ::pinocchio::fusion::JointUnaryVisitorBase<AABBStep> {
     aabb += max;
   }
 };
-
-template <>
-void AABBStep::algo<JointModelComposite>(
-    const ::pinocchio::JointModelBase<JointModelComposite>& jmodel,
-    const Model& model, Configuration_t q, bool initializeAABB,
-    fcl::AABB& aabb) {
-  // TODO this should for but I did not test it.
-  hppDout(warning,
-          "Computing AABB of JointModelComposite should work but has never "
-          "been tested");
-  if (initializeAABB) {
-    JointModelComposite::JointDataDerived data = jmodel.createData();
-    jmodel.calc(data, q);
-    aabb = fcl::AABB(data.M.translation());
-  }
-  ::pinocchio::details::Dispatch<AABBStep>::run(
-      jmodel.derived(), AABBStep::ArgsType(model, q, false, aabb));
-}
 
 fcl::AABB Device::computeAABB() const {
   // TODO check that user has called

--- a/src/joint.cc
+++ b/src/joint.cc
@@ -578,7 +578,6 @@ struct ConfigSpaceVisitor : public ::pinocchio::fusion::JointUnaryVisitorBase<
     typedef typename LieGroupMap_t::template operation<JointModel>::type LG_t;
     space *= LiegroupSpace::create(LG_t());
   }
-
 };
 
 LiegroupSpacePtr_t Joint::configurationSpace() const {

--- a/src/joint.cc
+++ b/src/joint.cc
@@ -579,10 +579,6 @@ struct ConfigSpaceVisitor : public ::pinocchio::fusion::JointUnaryVisitorBase<
     space *= LiegroupSpace::create(LG_t());
   }
 
-  static void _algo(const JointModelComposite& jmodel, LiegroupSpace& space) {
-    ::pinocchio::details::Dispatch<ConfigSpaceVisitor>::run(
-        jmodel, ConfigSpaceVisitor::ArgsType(space));
-  }
 };
 
 LiegroupSpacePtr_t Joint::configurationSpace() const {

--- a/src/joint/bound.hh
+++ b/src/joint/bound.hh
@@ -45,12 +45,5 @@ struct SetBoundStep
   }
 };
 
-template <>
-void SetBoundStep::algo<JointModelComposite>(
-    const ::pinocchio::JointModelBase<JointModelComposite>& jmodel,
-    ConfigurationIn_t bounds, Configuration_t& out) {
-  ::pinocchio::details::Dispatch<SetBoundStep>::run(jmodel.derived(),
-                                                    ArgsType(bounds, out));
-}
 }  // namespace pinocchio
 }  // namespace hpp


### PR DESCRIPTION
Add JointModelSpherical, JointModelSphericalZYX, and JointModelRevoluteUnboundedUnaligned to JointCollection.
Adding all new joints is not possible since a call to boost::list fails beyond 16 different types.

Remove JointComposite for compilation failure reasons.