### PR TITLE
[Gripper] Constructors take a shared pointer to device as input

### DIFF
--- a/include/hpp/pinocchio/gripper.hh
+++ b/include/hpp/pinocchio/gripper.hh
@@ -51,7 +51,7 @@ class HPP_PINOCCHIO_DLLAPI Gripper {
   /// \param name of the gripper in the device,
   /// \param device
   static GripperPtr_t create(const std::string& name,
-                             const DeviceWkPtr_t& device) {
+                             const DevicePtr_t& device) {
     Gripper* ptr = new Gripper(name, device);
     GripperPtr_t shPtr(ptr);
     ptr->init(shPtr);
@@ -59,7 +59,7 @@ class HPP_PINOCCHIO_DLLAPI Gripper {
   }
 
   static GripperPtr_t createCopy(const GripperPtr_t& gripper,
-                                 const DeviceWkPtr_t& otherDevice) {
+                                 const DevicePtr_t& otherDevice) {
     Gripper* ptr = new Gripper(gripper->name(), otherDevice);
     ptr->clearance(gripper->clearance());
     GripperPtr_t shPtr(ptr);
@@ -101,7 +101,7 @@ class HPP_PINOCCHIO_DLLAPI Gripper {
   /// \param device
   /// \todo device should be of type DeviceConstPtr_t but the constructor of
   /// JointPtr_t needs a DevicePtr_t.
-  Gripper(const std::string& name, const DeviceWkPtr_t& device);
+  Gripper(const std::string& name, const DevicePtr_t& device);
 
   void init(GripperWkPtr_t weakPtr) { weakPtr_ = weakPtr; }
 

--- a/src/device.cc
+++ b/src/device.cc
@@ -568,7 +568,8 @@ void Device::load(Archive& ar, const unsigned int version) {
       grippers_.reserve(grippers.size());
       std::transform(grippers.begin(), grippers.end(), grippers_.begin(),
                      [this](FrameIndex i) -> GripperPtr_t {
-                       return Gripper::create(model_->frames[i].name, weakPtr_.lock());
+                       return Gripper::create(model_->frames[i].name,
+                                              weakPtr_.lock());
                      });
       createData();
       createGeomData();

--- a/src/device.cc
+++ b/src/device.cc
@@ -128,7 +128,7 @@ void Device::initCopy(const DeviceWkPtr_t& weakPtr, const Device& other) {
   init(weakPtr);
   grippers_.resize(other.grippers_.size());
   for (std::size_t i = 0; i < grippers_.size(); ++i)
-    grippers_[i] = Gripper::createCopy(other.grippers_[i], weakPtr);
+    grippers_[i] = Gripper::createCopy(other.grippers_[i], weakPtr.lock());
 }
 
 void Device::createData() {
@@ -169,7 +169,7 @@ void Device::removeJoints(const std::vector<std::string>& jointNames,
   // update the grippers
   std::transform(grippers_.begin(), grippers_.end(), grippers_.begin(),
                  [this](GripperPtr_t g) {
-                   return Gripper::create(g->name(), this->weakPtr_);
+                   return Gripper::create(g->name(), this->weakPtr_.lock());
                  });
 
   invalidate();
@@ -568,7 +568,7 @@ void Device::load(Archive& ar, const unsigned int version) {
       grippers_.reserve(grippers.size());
       std::transform(grippers.begin(), grippers.end(), grippers_.begin(),
                      [this](FrameIndex i) -> GripperPtr_t {
-                       return Gripper::create(model_->frames[i].name, weakPtr_);
+                       return Gripper::create(model_->frames[i].name, weakPtr_.lock());
                      });
       createData();
       createGeomData();

--- a/src/gripper.cc
+++ b/src/gripper.cc
@@ -52,7 +52,9 @@ const Transform3s& Gripper::objectPositionInJoint() const {
   return model.frames[fid_].placement;
 }
 
-GripperPtr_t Gripper::clone() const { return Gripper::create(name_, device_.lock()); }
+GripperPtr_t Gripper::clone() const {
+  return Gripper::create(name_, device_.lock());
+}
 
 std::ostream& Gripper::print(std::ostream& os) const {
   os << "name :" << name() << std::endl;

--- a/src/gripper.cc
+++ b/src/gripper.cc
@@ -36,7 +36,7 @@
 
 namespace hpp {
 namespace pinocchio {
-Gripper::Gripper(const std::string& name, const DeviceWkPtr_t& device)
+Gripper::Gripper(const std::string& name, const DevicePtr_t& device)
     : name_(name), device_(device), clearance_(0) {
   DevicePtr_t d = this->device();
   fid_ = d->model().getFrameId(name);
@@ -52,7 +52,7 @@ const Transform3s& Gripper::objectPositionInJoint() const {
   return model.frames[fid_].placement;
 }
 
-GripperPtr_t Gripper::clone() const { return Gripper::create(name_, device_); }
+GripperPtr_t Gripper::clone() const { return Gripper::create(name_, device_.lock()); }
 
 std::ostream& Gripper::print(std::ostream& os) const {
   os << "name :" << name() << std::endl;


### PR DESCRIPTION
  instead of a weak pointer. This should not break the API since shared pointer
  are automatically cast into weak pointers.

  The goal is to clean up class hpp::manipulation::Device by removing the stored weak pointer to itself and using share_from_this method.