### PR TITLE
remove deprecated lastChild

### DIFF
--- a/src/center-of-mass-computation.cc
+++ b/src/center-of-mass-computation.cc
@@ -76,7 +76,7 @@ void CenterOfMassComputation::compute(DeviceData& d,
   std::size_t rootId = roots_[root];
   for (std::size_t jid = 1; jid < model.joints.size(); ++jid) {
     if (jid == rootId) {
-      jid = (std::size_t)data.lastChild[rootId];
+      jid = (std::size_t)model.children[rootId].back();
       root++;
       if (root < roots_.size())
         rootId = roots_[root];
@@ -102,8 +102,8 @@ void CenterOfMassComputation::compute(DeviceData& d,
     std::size_t rootId = roots_[(std::size_t)root];
 
     // Backward loop on descendents of joint rootId.
-    for (JointIndex jid = (JointIndex)data.lastChild[rootId]; jid >= rootId;
-         --jid) {
+    for (JointIndex jid = (JointIndex)model.children[rootId].back();
+         jid >= rootId; --jid) {
       if (computeJac)
         Pass::run(model.joints[jid], data.joints[jid],
                   Pass::ArgsType(model, data, data.Jcom, false));
@@ -149,18 +149,17 @@ CenterOfMassComputation::CenterOfMassComputation(const DevicePtr_t& d)
 }
 
 void CenterOfMassComputation::add(const JointPtr_t& j) {
-  const Data& data = robot_->data();
   JointIndex jid = j->index();
   BOOST_FOREACH (const JointIndex rootId, roots_) {
     assert(std::size_t(rootId) < robot_->model().joints.size());
     // Assert that the new root is not in already-recorded subtrees.
-    if ((jid >= rootId) && (data.lastChild[rootId] >= int(jid)))
+    if ((jid >= rootId) && (robot_->model().children[rootId].back() >= jid))
       // We are doing something stupid. Should we throw an error
       // or just return silently ?
       HPP_THROW(std::invalid_argument,
                 "Joint " << j->name() << " (" << jid
                          << ") is already in a subtree [" << rootId << ", "
-                         << data.lastChild[rootId] << "]");
+                         << robot_->model().children[rootId].back() << "]");
   }
 
   roots_.push_back(jid);

--- a/src/joint.cc
+++ b/src/joint.cc
@@ -69,11 +69,11 @@ Joint::Joint(DeviceWkPtr_t device, JointIndex indexInJointList)
 void Joint::setChildList() {
   assert(robot()->modelPtr());
   assert(robot()->dataPtr());
-  const Data& data = robot()->data();
   children.clear();
-  for (JointIndex child = jointIndex + 1;
-       int(child) <= data.lastChild[jointIndex]; ++child)
-    if (model().parents[child] == jointIndex) children.push_back(child);
+  if (!model().children[jointIndex].empty())
+    for (JointIndex child = jointIndex + 1;
+         child <= model().children[jointIndex].back(); ++child)
+      if (model().parents[child] == jointIndex) children.push_back(child);
 }
 
 inline void Joint::selfAssert() const {
@@ -240,9 +240,9 @@ value_type computeMaximalDistanceToParent(
     const SE3& jointPlacement) {
   const size_type& i = jmodel.idx_q();
   return computeMaximalDistanceToParentForAlignedTranslation<true, true, true>(
-      model.lowerPositionLimit.segment< ::pinocchio::JointModelTranslation::NQ>(
+      model.lowerPositionLimit.segment<::pinocchio::JointModelTranslation::NQ>(
           i),
-      model.upperPositionLimit.segment< ::pinocchio::JointModelTranslation::NQ>(
+      model.upperPositionLimit.segment<::pinocchio::JointModelTranslation::NQ>(
           i),
       jointPlacement);
 }
@@ -321,9 +321,9 @@ value_type computeMaximalDistanceToParent(
     const SE3& jointPlacement) {
   const size_type& i = jmodel.idx_q();
   return computeMaximalDistanceToParentForAlignedTranslation<true, true, true>(
-      model.lowerPositionLimit.segment< ::pinocchio::JointModelTranslation::NQ>(
+      model.lowerPositionLimit.segment<::pinocchio::JointModelTranslation::NQ>(
           i),
-      model.upperPositionLimit.segment< ::pinocchio::JointModelTranslation::NQ>(
+      model.upperPositionLimit.segment<::pinocchio::JointModelTranslation::NQ>(
           i),
       jointPlacement);
 }
@@ -557,7 +557,7 @@ std::ostream& Joint::display(std::ostream& os) const {
 
 template <typename LieGroupMap_t>
 struct ConfigSpaceVisitor : public ::pinocchio::fusion::JointUnaryVisitorBase<
-                                ConfigSpaceVisitor<LieGroupMap_t> > {
+                                ConfigSpaceVisitor<LieGroupMap_t>> {
   typedef boost::fusion::vector<LiegroupSpace&> ArgsType;
 
   template <typename JointModel>


### PR DESCRIPTION
ref. https://github.com/stack-of-tasks/pinocchio/issues/2926

```cpp
/home/gsaurel/local/humanoid-path-planner/hpp-pinocchio/src/joint.cc: In member function « void hpp::pinocchio::Joint::setChildList() »:
/home/gsaurel/local/humanoid-path-planner/hpp-pinocchio/src/joint.cc:75:27: attention: « pinocchio::DataTpl<double, 0>::lastChild » est obsolète [-Wdeprecated-declarations]
   75 |        int(child) <= data.lastChild[jointIndex]; ++child)
      |                           ^~~~~~~~~
Dans le fichier inclus depuis /nix/store/bcnjawippwa5msswkdc6p00b2lrba6ls-pinocchio-4.0.0/include/pinocchio/multibody.hpp:57,
                 depuis /nix/store/bcnjawippwa5msswkdc6p00b2lrba6ls-pinocchio-4.0.0/include/pinocchio/algorithm/jacobian.hpp:25,
                 depuis /home/gsaurel/local/humanoid-path-planner/hpp-pinocchio/src/joint.cc:41:
/nix/store/bcnjawippwa5msswkdc6p00b2lrba6ls-pinocchio-4.0.0/include/pinocchio/src/multibody/data.hxx:311:43: note: déclaré ici
  311 |     PINOCCHIO_DEPRECATED std::vector<int> lastChild;
      |                                           ^~~~~~~~~
/home/gsaurel/local/humanoid-path-planner/hpp-pinocchio/src/joint.cc:75:27: attention: « pinocchio::DataTpl<double, 0>::lastChild » est obsolète [-Wdeprecated-declarations]
   75 |        int(child) <= data.lastChild[jointIndex]; ++child)
      |                           ^~~~~~~~~
/nix/store/bcnjawippwa5msswkdc6p00b2lrba6ls-pinocchio-4.0.0/include/pinocchio/src/multibody/data.hxx:311:43: note: déclaré ici
  311 |     PINOCCHIO_DEPRECATED std::vector<int> lastChild;
      |                                           ^~~~~~~~~
/home/gsaurel/local/humanoid-path-planner/hpp-pinocchio/src/joint.cc:75:27: attention: « pinocchio::DataTpl<double, 0>::lastChild » est obsolète [-Wdeprecated-declarations]
   75 |        int(child) <= data.lastChild[jointIndex]; ++child)
      |                           ^~~~~~~~~
/nix/store/bcnjawippwa5msswkdc6p00b2lrba6ls-pinocchio-4.0.0/include/pinocchio/src/multibody/data.hxx:311:43: note: déclaré ici
  311 |     PINOCCHIO_DEPRECATED std::vector<int> lastChild;
      |                                           ^~~~~~~~~
```